### PR TITLE
feat: support parameterized notebook

### DIFF
--- a/common/types/notebooks.ts
+++ b/common/types/notebooks.ts
@@ -67,6 +67,7 @@ export interface NotebookContext {
   summary?: string;
   specs?: Array<Record<string, unknown>>;
   PPLFilters?: string[];
+  variables?: Record<string, unknown>;
 }
 
 export interface ParagraphBackendType {

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -580,7 +580,7 @@ export function NotebookComponent({
       })
       .catch((err) => {
         console.log(err);
-        if (err.body.statusCode === 413)
+        if (err?.body?.statusCode === 413)
           notifications.toasts.addDanger(`Error running paragraph: ${err.body.message}`);
         else
           notifications.toasts.addDanger(

--- a/server/common/helpers/notebooks/paragraph.test.ts
+++ b/server/common/helpers/notebooks/paragraph.test.ts
@@ -1,0 +1,331 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObject } from '../../../../../../src/core/server/types';
+import { NotebookContext } from '../../../../common/types/notebooks';
+import { updateParagraphText } from './paragraph';
+
+describe('updateParagraphText', () => {
+  const createMockNotebookInfo = (
+    variables?: Record<string, unknown>
+  ): SavedObject<{ savedNotebook: { context?: NotebookContext } }> => ({
+    id: 'test-notebook-id',
+    type: 'notebook',
+    references: [],
+    attributes: {
+      savedNotebook: {
+        context: variables ? { variables } : undefined,
+      },
+    },
+  });
+
+  describe('SQL paragraph processing', () => {
+    it('should replace variables in SQL query with prefix removal', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+        timeRange: '7d',
+        threshold: '1000',
+      });
+
+      const inputText =
+        '%sql SELECT * FROM ${index} WHERE timestamp > now() - INTERVAL ${timeRange} AND count > ${threshold}';
+      const expected =
+        'SELECT * FROM logs-* WHERE timestamp > now() - INTERVAL 7d AND count > 1000';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle SQL query with no variables', () => {
+      const mockNotebookInfo = createMockNotebookInfo();
+
+      const inputText = '%sql SELECT * FROM logs WHERE timestamp > now() - INTERVAL 1d';
+      const expected = 'SELECT * FROM logs WHERE timestamp > now() - INTERVAL 1d';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should preserve unmatched variable placeholders in SQL', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+      });
+
+      const inputText = '%sql SELECT * FROM ${index} WHERE field = ${undefinedVar}';
+      const expected = 'SELECT * FROM logs-* WHERE field = ${undefinedVar}';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle SQL query with complex variable values', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'my-index-2024-*',
+        aggregation: 'avg',
+        field: 'response_time',
+        condition: '> 500',
+      });
+
+      const inputText =
+        '%sql SELECT ${aggregation}(${field}) as result FROM ${index} WHERE ${field} ${condition}';
+      const expected =
+        'SELECT avg(response_time) as result FROM my-index-2024-* WHERE response_time > 500';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('PPL paragraph processing', () => {
+    it('should replace variables in PPL query with prefix removal', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'metrics-*',
+        timeField: '@timestamp',
+        aggregation: 'count',
+      });
+
+      const inputText =
+        '%ppl source=${index} | where ${timeField} > now() - 1d | stats ${aggregation}() by field';
+      const expected = 'source=metrics-* | where @timestamp > now() - 1d | stats count() by field';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle PPL query with multiple variable occurrences', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+        field: 'status',
+        value: 'error',
+      });
+
+      const inputText =
+        '%ppl source=${index} | where ${field}="${value}" | stats count() by ${field}';
+      const expected = 'source=logs-* | where status="error" | stats count() by status';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle PPL query with no variables', () => {
+      const mockNotebookInfo = createMockNotebookInfo();
+
+      const inputText = '%ppl source=logs-* | where status="error" | stats count()';
+      const expected = 'source=logs-* | where status="error" | stats count()';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('Markdown paragraph processing', () => {
+    it('should replace variables in markdown content with prefix removal', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        title: 'Daily Report',
+        date: '2024-01-15',
+        metric: 'response_time',
+      });
+
+      const inputText = '%md # ${title}\n\nReport generated on ${date} for ${metric} analysis.';
+      const expected =
+        '# Daily Report\n\nReport generated on 2024-01-15 for response_time analysis.';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle markdown with nested variable references', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        reportType: 'Performance',
+        timeRange: 'last 24 hours',
+        threshold: '500ms',
+      });
+
+      const inputText =
+        '%md ## ${reportType} Analysis\n\nThis ${reportType.toLowerCase()} report covers the ${timeRange} with a threshold of ${threshold}.';
+      const expected =
+        '## Performance Analysis\n\nThis performance report covers the last 24 hours with a threshold of 500ms.';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle markdown with no variables', () => {
+      const mockNotebookInfo = createMockNotebookInfo();
+
+      const inputText = '%md # Static Report\n\nThis is a static markdown content.';
+      const expected = '# Static Report\n\nThis is a static markdown content.';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('Edge cases and error handling', () => {
+    it('should handle empty input text', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+      });
+
+      const inputText = '%sql';
+      const expected = '';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle input text shorter than prefix', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+      });
+
+      const inputText = '%sq';
+      const expected = '';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle notebook info without context', () => {
+      const mockNotebookInfo = createMockNotebookInfo();
+
+      const inputText = '%sql SELECT * FROM ${index}';
+      const expected = 'SELECT * FROM ${index}';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle notebook info with empty context', () => {
+      const mockNotebookInfo = createMockNotebookInfo({});
+
+      const inputText = '%sql SELECT * FROM ${index}';
+      const expected = 'SELECT * FROM ${index}';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle variables with special characters', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        'index-name': 'logs-2024-*',
+        'field.name': 'response_time',
+        'special@var': 'value',
+      });
+
+      const inputText =
+        '%sql SELECT * FROM ${index-name} WHERE ${field.name} > 0 AND ${special@var} = "test"';
+      const expected = 'SELECT * FROM logs-2024-* WHERE response_time > 0 AND value = "test"';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle variables with numeric values', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        threshold: 1000,
+        limit: 100,
+        offset: 0,
+      });
+
+      const inputText =
+        '%sql SELECT * FROM logs WHERE count > ${threshold} LIMIT ${limit} OFFSET ${offset}';
+      const expected = 'SELECT * FROM logs WHERE count > 1000 LIMIT 100 OFFSET 0';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle variables with boolean values', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        enabled: true,
+        debug: false,
+      });
+
+      const inputText = '%sql SELECT * FROM logs WHERE enabled = ${enabled} AND debug = ${debug}';
+      const expected = 'SELECT * FROM logs WHERE enabled = true AND debug = false';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle variables with null values', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: null,
+        field: undefined,
+      });
+
+      const inputText = '%sql SELECT * FROM ${index} WHERE ${field} IS NOT NULL';
+      const expected = 'SELECT * FROM null WHERE undefined IS NOT NULL';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('Variable substitution patterns', () => {
+    it('should handle consecutive variable replacements', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        a: '1',
+        b: '2',
+        c: '3',
+      });
+
+      const inputText = '%sql SELECT ${a}, ${b}, ${c}';
+      const expected = 'SELECT 1, 2, 3';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle nested variable placeholders', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index: 'logs-*',
+        field: 'status',
+      });
+
+      const inputText = '%sql SELECT * FROM ${index} WHERE ${field} = "${field}_value"';
+      const expected = 'SELECT * FROM logs-* WHERE status = "status_value"';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+
+    it('should handle variable placeholders with underscores', () => {
+      const mockNotebookInfo = createMockNotebookInfo({
+        index_name: 'logs-*',
+        field_name: 'status',
+        table_name: 'events',
+      });
+
+      const inputText = '%sql SELECT * FROM ${table_name} WHERE ${field_name} = "error"';
+      const expected = 'SELECT * FROM events WHERE status = "error"';
+
+      const result = updateParagraphText(inputText, mockNotebookInfo);
+
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/server/common/helpers/notebooks/paragraph.ts
+++ b/server/common/helpers/notebooks/paragraph.ts
@@ -62,7 +62,7 @@ export const updateParagraphText = (
   } else {
     // Replace variables with values. eg: ${context.a[0].b.c} -> value
     const replacedVariablesInput = removedPrefixInput.replace(/\$\{([^}]+)\}/g, (match, path) => {
-      // Remove 'context.' prefix if it exists
+      // Currently we only support to retrieve value from context. So remove 'context.' prefix if it exists
       const cleanPath = path.startsWith('context.') ? path.substring(8) : path;
       const value = getNestedValue(context, cleanPath);
       // Handle null values - return "null" string instead of keeping placeholder

--- a/server/common/helpers/notebooks/paragraph.ts
+++ b/server/common/helpers/notebooks/paragraph.ts
@@ -12,7 +12,6 @@ export const updateParagraphText = (
   // Remove prefix. eg: %ppl
   const removedPrefixInput = inputText.substring(4, inputText.length);
   const variables = notebookInfo?.attributes?.savedNotebook?.context?.variables;
-  console.log('context', notebookInfo?.attributes?.savedNotebook?.context, 'variables', variables);
 
   if (!variables) {
     return removedPrefixInput;

--- a/server/common/helpers/notebooks/paragraph.ts
+++ b/server/common/helpers/notebooks/paragraph.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SavedObject } from '../../../../../../src/core/server/types';
+import { NotebookContext } from '../../../../common/types/notebooks';
+
+export const updateParagraphText = (
+  inputText: string,
+  notebookInfo: SavedObject<{ savedNotebook: { context?: NotebookContext } }>
+) => {
+  // Remove prefix. eg: %ppl
+  const removedPrefixInput = inputText.substring(4, inputText.length);
+  const variables = notebookInfo?.attributes?.savedNotebook?.context?.variables;
+  console.log('context', notebookInfo?.attributes?.savedNotebook?.context, 'variables', variables);
+
+  if (!variables) {
+    return removedPrefixInput;
+  } else {
+    // Replace variables with values. eg: ${index} -> 1
+    const replacedVariablesInput = removedPrefixInput.replace(
+      /\$\{(\w+)\}/g,
+      (match, key) => (variables[key] as string) || match
+    );
+    return replacedVariablesInput;
+  }
+};

--- a/server/common/helpers/notebooks/paragraph.ts
+++ b/server/common/helpers/notebooks/paragraph.ts
@@ -5,22 +5,75 @@
 import { SavedObject } from '../../../../../../src/core/server/types';
 import { NotebookContext } from '../../../../common/types/notebooks';
 
+// Helper function to get nested value from object (similar to Lodash _.get)
+const getNestedValue = (obj: any, path: string, defaultValue: any = undefined): any => {
+  if (!obj || !path) return defaultValue;
+
+  // Split by dots first, then handle array notation
+  const parts = path.split('.');
+  let current = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return defaultValue;
+    }
+
+    // Handle array notation like [0] or [1]
+    if (part.includes('[') && part.includes(']')) {
+      // Extract the property name and array index
+      const match = part.match(/^([^\[]+)\[(\d+)\]$/);
+      if (match) {
+        const [, propName, index] = match;
+        if (propName) {
+          current = current[propName];
+          if (current === null || current === undefined || !Array.isArray(current)) {
+            return defaultValue;
+          }
+          current = current[parseInt(index, 10)];
+        } else {
+          // Direct array access like [0]
+          current = current[parseInt(index, 10)];
+        }
+      } else {
+        return defaultValue;
+      }
+    } else {
+      current = current[part];
+    }
+
+    if (current === undefined) {
+      return defaultValue;
+    }
+  }
+
+  return current;
+};
+
 export const updateParagraphText = (
   inputText: string,
   notebookInfo: SavedObject<{ savedNotebook: { context?: NotebookContext } }>
 ) => {
   // Remove prefix. eg: %ppl
-  const removedPrefixInput = inputText.substring(4, inputText.length);
-  const variables = notebookInfo?.attributes?.savedNotebook?.context?.variables;
+  const removedPrefixInput = inputText.replace(/^%\w+\s+/, '');
+  const context = notebookInfo?.attributes?.savedNotebook?.context;
 
-  if (!variables) {
+  if (!context) {
     return removedPrefixInput;
   } else {
-    // Replace variables with values. eg: ${index} -> 1
-    const replacedVariablesInput = removedPrefixInput.replace(
-      /\$\{(\w+)\}/g,
-      (match, key) => (variables[key] as string) || match
-    );
+    // Replace variables with values. eg: ${context.a[0].b.c} -> value
+    const replacedVariablesInput = removedPrefixInput.replace(/\$\{([^}]+)\}/g, (match, path) => {
+      // Remove 'context.' prefix if it exists
+      const cleanPath = path.startsWith('context.') ? path.substring(8) : path;
+      const value = getNestedValue(context, cleanPath);
+      // Handle null values - return "null" string instead of keeping placeholder
+      if (value === null) {
+        return 'null';
+      }
+      if (value !== undefined) {
+        return String(value);
+      }
+      return match;
+    });
     return replacedVariablesInput;
   }
 };


### PR DESCRIPTION
### Description
Create notebook with context:
```
{
  variables: {
    index: "logs-",
    timeField: "@timestamp",
    aggregation: "avg"
  }
}
```

Paragraph Content:
```
%sql
SELECT ${context.variables.aggregation}(value) as result 
FROM ${context.variables.index} 
WHERE ${context.variables.timeField} > now() - INTERVAL 1 day
```

Result: The query becomes:
```
SELECT avg(value) as result 
FROM logs- 
WHERE @timestamp > now() - INTERVAL 1 day
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
