### PR TITLE
Improve input component workflow and data flow

### DIFF
--- a/common/types/notebooks.ts
+++ b/common/types/notebooks.ts
@@ -81,6 +81,8 @@ export interface ParagraphBackendType<TOutputResult, TInputParameters = unknown>
   dataSourceMDSId?: string;
 }
 
+export type ParagraphInputType<TParameters = unknown> = ParagraphBackendType<TParameters>['input'];
+
 export interface NotebookBackendType {
   name: string;
   dateCreated: string;

--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -3,20 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { createContext, useContext, useState, useRef, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useRef,
+  ReactNode,
+  useMemo,
+  useCallback,
+} from 'react';
 import { useObservable } from 'react-use';
 import type { monaco } from '@osd/monaco';
 import { NoteBookServices } from 'public/types';
 import { EuiSelectableOption } from '@elastic/eui';
-import { InputType, QueryLanguage, QueryState, InputValueType, InputTypeOption } from './types';
-import { useInputSubmit } from './use_input_submit';
-import { useOpenSearchDashboards } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+// import { useAgentSelectSubmit } from './use_agent_select_submit';
 import {
-  AI_RESPONSE_TYPE,
-  DEEP_RESEARCH_PARAGRAPH_TYPE,
-} from '../../../../../common/constants/notebooks';
+  InputType,
+  QueryLanguage,
+  QueryState,
+  InputValueType,
+  InputTypeOption,
+  ParagraphInputType,
+} from './types';
+import { useOpenSearchDashboards } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
 import { NotebookReactContext } from '../../context_provider/context_provider';
-import { useParagraphs } from '../../../../../public/hooks/use_paragraphs';
 import {
   QueryAssistParameters,
   QueryAssistResponse,
@@ -70,7 +81,7 @@ interface InputContextValue<T extends InputType = InputType> {
   handleSubmit: (payload?: any) => void;
 
   // Handle open the popover for creating blank
-  handleParagraphSelection: (options: EuiSelectableOption[]) => Promise<void>;
+  handleParagraphSelection: (options: EuiSelectableOption[]) => void;
 
   // For query editor
   editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
@@ -83,23 +94,14 @@ const InputContext = createContext<InputContextValue | undefined>(undefined);
 
 interface InputProviderProps<TParameters = unknown> {
   children: ReactNode;
-  onSubmit?: (paragraphInput: string, inputType: string) => void;
-  input?: {
-    inputText: string;
-    inputType: string;
-    parameters?: TParameters;
-  };
+  onSubmit: (input: ParagraphInputType<TParameters>) => void;
+  input?: ParagraphInputType<TParameters>;
 }
 
 export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit, input }) => {
   const {
     services: { http, data },
   } = useOpenSearchDashboards<NoteBookServices>();
-  const { createParagraph } = useParagraphs();
-  const paragraphs = useObservable(
-    useContext(NotebookReactContext).state.getValue$(),
-    useContext(NotebookReactContext).state.value
-  ).paragraphs.map((item) => item.value);
 
   const [currInputType, setCurrInputType] = useState<InputType>(
     (input?.inputType as InputType) || AI_RESPONSE_TYPE
@@ -112,12 +114,17 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
       // FIXME: remove this when the executing of a query is properly implemented
       const cleanedQuery = input.inputText.replace(TIME_FILTER_QUERY_REGEX, '');
 
+      const { timeRange, question } = (input.parameters as any) || {};
+
       return {
-        value: cleanedQuery || '',
-        query: '',
+        // Use natural language question as input text if is t2ppl
+        value: question || cleanedQuery || '',
+        // Set generated query if is t2ppl
+        query: question ? cleanedQuery.replace(TIME_FILTER_QUERY_REGEX, '') : '',
         queryLanguage: input.inputType as QueryLanguage,
-        isPromptEditorMode: false, // FIXME
-        timeRange: { from: 'now-15m', to: 'now' },
+        // If question is defined, indicate the user executed t2ppl previously
+        isPromptEditorMode: !!question,
+        timeRange,
         selectedIndex: data.query.queryString.getDefaultQuery().dataset, // FIXME
         parameters: input.parameters,
       } as InputValueType<typeof currInputType>;
@@ -169,99 +176,58 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
     context.state.value.context.value
   );
 
-  const paragraphOptions = [
-    {
-      key: AI_RESPONSE_TYPE,
-      icon: 'chatLeft',
-      label: 'Ask AI',
-      'data-test-subj': 'paragraph-type-nl',
-    },
-    { key: 'PPL', icon: 'compass', label: 'Query', 'data-test-subj': 'paragraph-type-ppl' },
-    {
-      key: 'DEEP_RESEARCH_AGENT',
-      icon: 'generate',
-      label: 'Continue investigation',
-      'data-test-subj': 'paragraph-type-deep-research',
-      disabled: !initialGoal,
-    },
-    { key: 'MARKDOWN', icon: 'pencil', label: 'Note', 'data-test-subj': 'paragraph-type-markdown' },
-    {
-      label: 'Visualization',
-      key: 'VISUALIZATION',
-      icon: 'lineChart',
-      'data-test-subj': 'paragraph-type-visualization',
-    },
-  ].filter((item) => !item.disabled);
+  const paragraphOptions = useMemo(
+    () =>
+      [
+        {
+          key: AI_RESPONSE_TYPE,
+          icon: 'chatLeft',
+          label: 'Ask AI',
+          'data-test-subj': 'paragraph-type-nl',
+        },
+        { key: 'PPL', icon: 'compass', label: 'Query', 'data-test-subj': 'paragraph-type-ppl' },
+        {
+          key: 'DEEP_RESEARCH_AGENT',
+          icon: 'generate',
+          label: 'Continue investigation',
+          'data-test-subj': 'paragraph-type-deep-research',
+          disabled: !initialGoal,
+        },
+        {
+          key: 'MARKDOWN',
+          icon: 'pencil',
+          label: 'Note',
+          'data-test-subj': 'paragraph-type-markdown',
+        },
+        {
+          label: 'Visualization',
+          key: 'VISUALIZATION',
+          icon: 'lineChart',
+          'data-test-subj': 'paragraph-type-visualization',
+        },
+      ].filter((item) => !item.disabled),
+    [initialGoal]
+  );
 
-  const handleCancel = () => {
-    setInputValue(undefined);
+  const handleCancel = useCallback(() => {
+    setInputValue('');
     setCurrInputType(AI_RESPONSE_TYPE);
-  };
+  }, []);
 
-  const handleCreateParagraph = async (paragraphInput: string | object, inputType: string) => {
-    setIsLoading(true);
-    // Add paragraph at the end
-    await createParagraph({
-      index: paragraphs.length,
-      input: {
-        inputText:
-          typeof paragraphInput === 'object' ? JSON.stringify(paragraphInput) : paragraphInput,
-        inputType,
-      },
-    });
+  // const { handleAgentSelectSubmit } = useAgentSelectSubmit({
+  //   http,
+  //   dataSourceId,
+  //   onSubmit,
+  //   setIsLoading,
+  // });
 
-    handleCancel();
-
-    setIsLoading(false);
-  };
-
-  const { onAskAISubmit } = useInputSubmit({
-    http,
-    dataSourceId,
-    onSubmit: handleCreateParagraph,
-    setIsLoading,
-  });
-
-  const handleParagraphSelection = async (options: EuiSelectableOption[]) => {
+  const handleParagraphSelection = (options: EuiSelectableOption[]) => {
     const selectedOption = options.find((option) => option.checked === 'on');
     if (selectedOption) {
       const paragraphType = selectedOption.key as InputType;
 
-      // Determine paragraph type and input content
-      let inputType = 'CODE';
-      let paragraphInput = '';
-
-      switch (paragraphType) {
-        case 'PPL':
-          inputType = 'CODE';
-          paragraphInput = '%ppl\n';
-          break;
-        case 'SQL':
-          inputType = 'CODE';
-          paragraphInput = '%sql\n';
-          break;
-        case 'MARKDOWN':
-          inputType = 'CODE';
-          paragraphInput = '%md\n';
-          break;
-        case 'VISUALIZATION':
-          inputType = 'VISUALIZATION';
-          paragraphInput = '';
-          break;
-        case 'DEEP_RESEARCH_AGENT':
-          inputType = DEEP_RESEARCH_PARAGRAPH_TYPE;
-          paragraphInput = '';
-          break;
-        case AI_RESPONSE_TYPE:
-          inputType = AI_RESPONSE_TYPE;
-          paragraphInput = '';
-          break;
-        default:
-          inputType = 'CODE';
-          paragraphInput = '';
-      }
-
-      handleCreateParagraph(paragraphInput, inputType);
+      // Create empty paragraph
+      onSubmit({ inputText: '', inputType: paragraphType });
 
       setIsParagraphSelectionOpen(false);
       handleInputChange('');
@@ -271,29 +237,26 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
 
   const isInputMountedInParagraph = !!input;
 
-  const submitFn = isInputMountedInParagraph && onSubmit ? onSubmit : handleCreateParagraph;
+  const calculateQueryWithTimeFilter = useCallback(
+    (query: string, timeRange: TimeRange, selectedIndex: any) => {
+      const queryState = inputValue as QueryState;
+      if (TIME_FILTER_QUERY_REGEX.test(query) || queryState?.parameters?.noDatePicker) {
+        return query;
+      }
 
-  const calculateQueryWithTimeFilter = (
-    query: string,
-    timeRange: TimeRange,
-    selectedIndex: any
-  ) => {
-    const queryState = inputValue as QueryState;
-    if (TIME_FILTER_QUERY_REGEX.test(query) || queryState.parameters?.noDatePicker) {
-      return query;
-    }
+      const { fromDate, toDate } = formatTimePickerDate(timeRange, TIME_FILTER_FORMAT);
+      const timeFieldName = selectedIndex.timeFieldName;
+      const whereCommand = timeFieldName
+        ? `WHERE \`${timeFieldName}\` >= '${fromDate}' AND \`${timeFieldName}\` <= '${toDate}'`
+        : '';
 
-    const { fromDate, toDate } = formatTimePickerDate(timeRange, TIME_FILTER_FORMAT);
-    const timeFieldName = selectedIndex.timeFieldName;
-    const whereCommand = timeFieldName
-      ? `WHERE \`${timeFieldName}\` >= '${fromDate}' AND \`${timeFieldName}\` <= '${toDate}'`
-      : '';
-
-    // Append time filter where command after the first command
-    const commands = query.split('|');
-    commands.splice(1, 0, whereCommand);
-    return commands.map((cmd) => cmd.trim()).join(' | ');
-  };
+      // Append time filter where command after the first command
+      const commands = query.split('|');
+      commands.splice(1, 0, whereCommand);
+      return commands.map((cmd) => cmd.trim()).join(' | ');
+    },
+    [inputValue]
+  );
 
   const handleGenerateQuery = async () => {
     const params: QueryAssistParameters = {
@@ -312,7 +275,7 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
     return query;
   };
 
-  const handleSubmit = async (payload?: any) => {
+  const handleSubmit = async (payload?: unknown) => {
     if (!payload && !inputValue) {
       return;
     }
@@ -321,31 +284,27 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
 
     try {
       switch (currInputType) {
-        case AI_RESPONSE_TYPE:
-          onAskAISubmit(inputValue as string, () => setInputValue(''));
-          break;
-        case 'DEEP_RESEARCH_AGENT':
-          submitFn(inputValue as string, DEEP_RESEARCH_PARAGRAPH_TYPE);
-          break;
-        case 'MARKDOWN':
-          submitFn(`%md ${inputValue}`, currInputType);
-          setInputValue('');
-          break;
         case 'SQL':
-          submitFn(`%sql\n${editorTextRef.current}`, 'CODE');
+          onSubmit({ inputText: editorTextRef.current, inputType: 'SQL' });
           break;
         case 'PPL':
+          // Specially handle PPL to insert timerange and natural language information
           const { timeRange, selectedIndex, isPromptEditorMode } = inputValue as QueryState;
           const query = isPromptEditorMode ? await handleGenerateQuery() : editorTextRef.current;
-          submitFn(
-            `%ppl\n${calculateQueryWithTimeFilter(query, timeRange, selectedIndex)}`,
-            'CODE'
-          );
-          break;
-        case 'VISUALIZATION':
+          onSubmit({
+            inputText: calculateQueryWithTimeFilter(query, timeRange, selectedIndex),
+            inputType: 'PPL',
+            parameters: {
+              timeRange,
+              ...(isPromptEditorMode && { question: editorTextRef.current }),
+            },
+          });
           break;
         default:
+          onSubmit({ inputText: inputValue as string, inputType: currInputType });
       }
+
+      if (!isInputMountedInParagraph) handleCancel();
     } catch (err) {
       console.log('error while execute the input', err);
     } finally {

--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -16,15 +16,9 @@ import { useObservable } from 'react-use';
 import type { monaco } from '@osd/monaco';
 import { NoteBookServices } from 'public/types';
 import { EuiSelectableOption } from '@elastic/eui';
+import { ParagraphInputType } from 'common/types/notebooks';
 // import { useAgentSelectSubmit } from './use_agent_select_submit';
-import {
-  InputType,
-  QueryLanguage,
-  QueryState,
-  InputValueType,
-  InputTypeOption,
-  ParagraphInputType,
-} from './types';
+import { InputType, QueryLanguage, QueryState, InputValueType, InputTypeOption } from './types';
 import { useOpenSearchDashboards } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
 import { NotebookReactContext } from '../../context_provider/context_provider';
@@ -120,7 +114,7 @@ export const InputProvider: React.FC<InputProviderProps> = ({ children, onSubmit
         // Use natural language question as input text if is t2ppl
         value: question || cleanedQuery || '',
         // Set generated query if is t2ppl
-        query: question ? cleanedQuery.replace(TIME_FILTER_QUERY_REGEX, '') : '',
+        query: question ? cleanedQuery : '',
         queryLanguage: input.inputType as QueryLanguage,
         // If question is defined, indicate the user executed t2ppl previously
         isPromptEditorMode: !!question,

--- a/public/components/notebooks/components/input/multi_variant_input.tsx
+++ b/public/components/notebooks/components/input/multi_variant_input.tsx
@@ -14,13 +14,13 @@ import {
 } from '@elastic/eui';
 import autosize from 'autosize';
 import { useEffectOnce } from 'react-use';
+import { ParagraphInputType } from 'common/types/notebooks';
 import { InputTypeSelector } from './input_type_selector';
 import { QueryPanel } from './query_panel';
 import { InputProvider, useInputContext } from './input_context';
 import { NotebookInput } from './notebook_input';
 import { MarkDownInput } from './markdown_input';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
-import { ParagraphInputType } from './types';
 
 interface MultiVariantInputProps<TParameters = unknown> {
   input?: ParagraphInputType<TParameters>;

--- a/public/components/notebooks/components/input/multi_variant_input.tsx
+++ b/public/components/notebooks/components/input/multi_variant_input.tsx
@@ -20,10 +20,11 @@ import { InputProvider, useInputContext } from './input_context';
 import { NotebookInput } from './notebook_input';
 import { MarkDownInput } from './markdown_input';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
+import { ParagraphInputType } from './types';
 
 interface MultiVariantInputProps<TParameters = unknown> {
-  input?: { inputText: string; inputType: string; parameters?: TParameters };
-  onSubmit?: (paragraphInput: any, inputType: string) => void;
+  input?: ParagraphInputType<TParameters>;
+  onSubmit: (input: ParagraphInputType<TParameters>) => void;
 }
 
 const MultiVariantInputContent: React.FC = () => {

--- a/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
@@ -48,9 +48,7 @@ export const QueryPanelEditor: React.FC<{ promptModeIsAvailable: boolean }> = ({
     promptModeIsAvailable: queryLanguage === 'SQL' ? false : promptModeIsAvailable,
     isPromptEditorMode,
     queryLanguage,
-    // FIXME when no need %ppl and %sql
-    userQueryString:
-      value?.startsWith('%ppl') || value?.startsWith('%sql') ? value.slice(5) : value,
+    userQueryString: value,
     handleRun: useCallback(() => {
       handleSubmit();
     }, [handleSubmit]),

--- a/public/components/notebooks/components/input/types.ts
+++ b/public/components/notebooks/components/input/types.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { ParagraphBackendType } from 'common/types/notebooks';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
 import { TimeRange } from '../../../../../../../src/plugins/data/common';
 
@@ -36,3 +37,5 @@ export interface InputTypeOption {
   'data-test-subj': string;
   disabled?: boolean;
 }
+
+export type ParagraphInputType<TParameters = unknown> = ParagraphBackendType<TParameters>['input'];

--- a/public/components/notebooks/components/input/types.ts
+++ b/public/components/notebooks/components/input/types.ts
@@ -2,7 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ParagraphBackendType } from 'common/types/notebooks';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
 import { TimeRange } from '../../../../../../../src/plugins/data/common';
 
@@ -37,5 +36,3 @@ export interface InputTypeOption {
   'data-test-subj': string;
   disabled?: boolean;
 }
-
-export type ParagraphInputType<TParameters = unknown> = ParagraphBackendType<TParameters>['input'];

--- a/public/components/notebooks/components/input/use_agent_select_submit.ts
+++ b/public/components/notebooks/components/input/use_agent_select_submit.ts
@@ -4,16 +4,16 @@
  */
 
 import { isEmpty } from 'lodash';
+import { ParagraphInputType } from 'common/types/notebooks';
 import { CoreStart } from '../../../../../../../src/core/public';
 import { ActionMetadata, actionsMetadata } from '../../../../../common/constants/actions';
 import { executeMLCommonsAgent, getMLCommonsConfig } from '../../../../utils/ml_commons_apis';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
-import { ParagraphInputType } from './types';
 
-interface AgentSelectSubmitHookProps {
+interface AgentSelectSubmitHookProps<TParameters = unknown> {
   http: CoreStart['http'];
   dataSourceId: string | undefined | null;
-  onSubmit: (input: ParagraphInputType) => void;
+  onSubmit: (input: ParagraphInputType<TParameters>) => void;
   setIsLoading: (loading: boolean) => void;
 }
 

--- a/public/components/notebooks/components/input/use_agent_select_submit.ts
+++ b/public/components/notebooks/components/input/use_agent_select_submit.ts
@@ -8,20 +8,21 @@ import { CoreStart } from '../../../../../../../src/core/public';
 import { ActionMetadata, actionsMetadata } from '../../../../../common/constants/actions';
 import { executeMLCommonsAgent, getMLCommonsConfig } from '../../../../utils/ml_commons_apis';
 import { AI_RESPONSE_TYPE } from '../../../../../common/constants/notebooks';
+import { ParagraphInputType } from './types';
 
-interface UseInputSubmitProps {
+interface AgentSelectSubmitHookProps {
   http: CoreStart['http'];
   dataSourceId: string | undefined | null;
-  onSubmit: (paragraphInput: string, inputType: string) => void;
+  onSubmit: (input: ParagraphInputType) => void;
   setIsLoading: (loading: boolean) => void;
 }
 
-export const useInputSubmit = ({
+export const useAgentSelectSubmit = ({
   http,
   dataSourceId,
   onSubmit,
   setIsLoading,
-}: UseInputSubmitProps) => {
+}: AgentSelectSubmitHookProps) => {
   const executeActionSelectionAgent = async (input: string, actions: ActionMetadata[]) => {
     try {
       const {
@@ -52,7 +53,7 @@ export const useInputSubmit = ({
       throw error;
     }
   };
-  const onAskAISubmit = async (inputValue: string, onSuccess: () => void) => {
+  const handleAgentSelectSubmit = async (inputValue: string, onSuccess: () => void) => {
     setIsLoading(true);
 
     if (!inputValue || isEmpty(inputValue.trim())) {
@@ -63,18 +64,22 @@ export const useInputSubmit = ({
       const response = await executeActionSelectionAgent(inputValue, actionsMetadata);
       const rawResult = JSON.parse(response?.inference_results?.[0]?.output?.[0]?.result);
       const jsonMatch = rawResult?.content?.[0]?.text?.match(/\{[\s\S]*\}/);
-      let inputType = 'CODE';
+      let inputType = AI_RESPONSE_TYPE;
       let paragraphInput = '';
       if (jsonMatch) {
         const result = JSON.parse(jsonMatch[0]);
         switch (result.action) {
           case 'PPL':
-            inputType = 'CODE';
-            paragraphInput = '%ppl\n' + result.input?.inputQuery || '';
+            inputType = 'PPL';
+            paragraphInput = result.input?.inputQuery || '';
+            break;
+          case 'SQL':
+            inputType = 'SQL';
+            paragraphInput = result.input?.inputQuery || '';
             break;
           case 'MARKDOWN':
-            inputType = 'CODE';
-            paragraphInput = '%md\n' + result.input?.markdownText || '';
+            inputType = 'MARKDOWN';
+            paragraphInput = result.input?.markdownText || '';
             break;
           case 'VISUALIZATION':
             inputType = 'VISUALIZATION';
@@ -85,11 +90,11 @@ export const useInputSubmit = ({
             paragraphInput = result.input?.question || '';
             break;
           default:
-            inputType = 'CODE';
+            inputType = AI_RESPONSE_TYPE;
             paragraphInput = inputValue;
         }
       }
-      await onSubmit(paragraphInput, inputType);
+      onSubmit({ inputText: paragraphInput, inputType });
       onSuccess();
     } catch (error) {
       console.error('Error occured during submission', error);
@@ -99,6 +104,6 @@ export const useInputSubmit = ({
   };
 
   return {
-    onAskAISubmit,
+    handleAgentSelectSubmit,
   };
 };

--- a/public/components/notebooks/components/input_panel.tsx
+++ b/public/components/notebooks/components/input_panel.tsx
@@ -3,11 +3,58 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useCallback, useContext } from 'react';
+import { useObservable } from 'react-use';
 import { EuiPanel } from '@elastic/eui';
 import { MultiVariantInput } from './input/multi_variant_input';
+import { ParagraphInputType } from './input/types';
+import { useParagraphs } from '../../../../public/hooks/use_paragraphs';
+import { NotebookReactContext } from '../context_provider/context_provider';
 
 export const InputPanel: React.FC = () => {
+  const { createParagraph } = useParagraphs();
+
+  const context = useContext(NotebookReactContext);
+  const notebookState = useObservable(context.state.getValue$(), context.state.value);
+  const paragraphs = notebookState.paragraphs.map((item) => item.value);
+  const { dataSourceId } = useObservable(
+    context.state.value.context.getValue$(),
+    context.state.value.context.value
+  );
+
+  const handleCreateParagraph = useCallback(
+    async ({ inputText, inputType, parameters }: ParagraphInputType) => {
+      let typedInputText = inputText;
+      let createInputType = inputType;
+
+      switch (inputType) {
+        case 'SQL':
+          typedInputText = `%sql\n${inputText}`;
+          createInputType = 'CODE';
+          break;
+        case 'PPL':
+          typedInputText = `%ppl\n${inputText}`;
+          createInputType = 'CODE';
+          break;
+        case 'MARKDOWN':
+          typedInputText = `%md\n${inputText}`;
+          break;
+      }
+
+      // Add paragraph at the end
+      await createParagraph({
+        index: paragraphs.length,
+        input: {
+          inputText: typedInputText,
+          inputType: createInputType,
+          parameters,
+        },
+        dataSourceMDSId: dataSourceId,
+      });
+    },
+    [paragraphs.length, dataSourceId, createParagraph]
+  );
+
   return (
     <div
       style={{
@@ -20,7 +67,7 @@ export const InputPanel: React.FC = () => {
       }}
     >
       <EuiPanel grow borderRadius="xl" hasBorder hasShadow paddingSize="s">
-        <MultiVariantInput />
+        <MultiVariantInput onSubmit={handleCreateParagraph} />
       </EuiPanel>
     </div>
   );

--- a/public/components/notebooks/components/paragraph_components/deep_research/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/deep_research/index.tsx
@@ -32,10 +32,7 @@ import { getSystemPrompts } from '../../helpers/custom_modals/system_prompt_sett
 import { AgentsSelector } from './agents_selector';
 import { DeepResearchOutput } from './deep_research_output';
 import { NotebookReactContext } from '../../../context_provider/context_provider';
-import {
-  AI_RESPONSE_TYPE,
-  DEEP_RESEARCH_PARAGRAPH_TYPE,
-} from '../../../../../../common/constants/notebooks';
+import { DEEP_RESEARCH_PARAGRAPH_TYPE } from '../../../../../../common/constants/notebooks';
 
 export const DeepResearchParagraph = ({
   paragraphState,
@@ -97,20 +94,6 @@ export const DeepResearchParagraph = ({
     },
     [runParagraph, paragraphState, paragraphValue.id]
   );
-
-  useEffect(() => {
-    if (
-      !paragraphValue.uiState?.isRunning &&
-      paragraphValue.input.inputType === AI_RESPONSE_TYPE &&
-      paragraphValue.input.parameters?.agentId &&
-      !outputResult?.taskId
-    ) {
-      // automatically run ai response paragraph when create initially
-      runParagraphHandler({
-        inputText: paragraphValue.input.inputText,
-      });
-    }
-  }, [paragraphValue, outputResult, runParagraphHandler]);
 
   useEffect(() => {
     if (

--- a/public/components/notebooks/components/paragraph_components/deep_research/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/deep_research/index.tsx
@@ -32,7 +32,10 @@ import { getSystemPrompts } from '../../helpers/custom_modals/system_prompt_sett
 import { AgentsSelector } from './agents_selector';
 import { DeepResearchOutput } from './deep_research_output';
 import { NotebookReactContext } from '../../../context_provider/context_provider';
-import { DEEP_RESEARCH_PARAGRAPH_TYPE } from '../../../../../../common/constants/notebooks';
+import {
+  AI_RESPONSE_TYPE,
+  DEEP_RESEARCH_PARAGRAPH_TYPE,
+} from '../../../../../../common/constants/notebooks';
 
 export const DeepResearchParagraph = ({
   paragraphState,
@@ -94,6 +97,20 @@ export const DeepResearchParagraph = ({
     },
     [runParagraph, paragraphState, paragraphValue.id]
   );
+
+  useEffect(() => {
+    if (
+      !paragraphValue.uiState?.isRunning &&
+      paragraphValue.input.inputType === AI_RESPONSE_TYPE &&
+      paragraphValue.input.parameters?.agentId &&
+      !outputResult?.taskId
+    ) {
+      // automatically run ai response paragraph when create initially
+      runParagraphHandler({
+        inputText: paragraphValue.input.inputText,
+      });
+    }
+  }, [paragraphValue, outputResult, runParagraphHandler]);
 
   useEffect(() => {
     if (
@@ -198,7 +215,7 @@ export const DeepResearchParagraph = ({
           outputResult={outputResult}
           dataSourceId={selectedDataSource}
           http={http}
-          input={paragraphValue.input.parameters || paragraphValue.input}
+          input={paragraphValue.input.parameters || (paragraphValue.input as any)}
         />
       )}
     </>

--- a/public/components/notebooks/components/paragraph_components/ppl/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/ppl/index.tsx
@@ -162,6 +162,19 @@ export const PPLParagraph = ({
     }
   }, [paragraphValue, loadQueryResultsFromInput, searchQuery]);
 
+  useEffect(() => {
+    if (
+      !paragraphValue.uiState?.isRunning &&
+      // Check if the ouput is default data structure
+      paragraphValue.output?.[0].outputType === 'MARKDOWN' &&
+      paragraphValue.output?.[0].result === ''
+    ) {
+      runParagraph({
+        id: paragraphValue.id,
+      });
+    }
+  }, [paragraphValue, runParagraph]);
+
   const runParagraphHandler = async () => {
     const inputText = paragraphState.getBackendValue().input.inputText;
     const queryType = inputText.substring(0, 4) === '%sql' ? '_sql' : '_ppl';
@@ -249,9 +262,10 @@ export const PPLParagraph = ({
               inputType: getInputType(paragraphValue).toUpperCase(),
               parameters: paragraphValue.input.parameters,
             }}
-            onSubmit={(value) => {
+            onSubmit={({ inputText, inputType, parameters }) => {
               paragraphState.updateInput({
-                inputText: value,
+                inputText: inputType === 'SQL' ? `%sql\n${inputText}` : `%ppl\n${inputText}`,
+                parameters,
               });
               paragraphState.updateUIState({
                 isOutputStale: true,

--- a/public/components/notebooks/components/paragraph_components/ppl/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/ppl/index.tsx
@@ -162,19 +162,6 @@ export const PPLParagraph = ({
     }
   }, [paragraphValue, loadQueryResultsFromInput, searchQuery]);
 
-  useEffect(() => {
-    if (
-      !paragraphValue.uiState?.isRunning &&
-      // Check if the ouput is default data structure
-      paragraphValue.output?.[0].outputType === 'MARKDOWN' &&
-      paragraphValue.output?.[0].result === ''
-    ) {
-      runParagraph({
-        id: paragraphValue.id,
-      });
-    }
-  }, [paragraphValue, runParagraph]);
-
   const runParagraphHandler = async () => {
     const inputText = paragraphState.getBackendValue().input.inputText;
     const queryType = inputText.substring(0, 4) === '%sql' ? '_sql' : '_ppl';


### PR DESCRIPTION
### Description
This PR has the following changes:
1. Move create paragraph function and handling for % prefix away from the input context
2. Persist time picker value to paragraph.input.parameters if it is enabled
3. Run the paragraph when the PPL query paragraph is created
4. Let ask AI input create a AI response paragraph by default
5. Automatically run the PPL and AI response paragraph when created
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
