### PR TITLE
fix: disable sorting to improve performance

### DIFF
--- a/public/components/notebooks/components/paragraph_components/para_query_grid.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_query_grid.tsx
@@ -21,18 +21,9 @@ interface RenderCellValueProps {
 function QueryDataGrid(props: QueryDataGridProps) {
   const { rowCount, queryColumns, dataValues } = props;
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
-  // ** Sorting config
-  const [sortingColumns, setSortingColumns] = useState([]);
   const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
 
   const [isVisible, setIsVisible] = useState(false);
-
-  const onSort = useCallback(
-    (newColumns) => {
-      setSortingColumns(newColumns);
-    },
-    [setSortingColumns]
-  );
 
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -53,15 +44,15 @@ function QueryDataGrid(props: QueryDataGridProps) {
     return ({ rowIndex, columnId }: RenderCellValueProps) => {
       return dataValues.hasOwnProperty(rowIndex) ? dataValues[rowIndex][columnId] : null;
     };
-  }, []);
+  }, [dataValues]);
 
-  const getUpdatedVisibleColumns = () => {
+  const getUpdatedVisibleColumns = useCallback(() => {
     const updatedVisibleColumns = [];
     for (let index = 0; index < queryColumns.length; ++index) {
       updatedVisibleColumns.push(queryColumns[index].displayAsText);
     }
     return updatedVisibleColumns;
-  };
+  }, [queryColumns]);
 
   useEffect(() => {
     if ($('.euiDataGrid__overflow').is(':visible')) {
@@ -73,7 +64,7 @@ function QueryDataGrid(props: QueryDataGridProps) {
       }
     }, 1000);
     setVisibleColumns(getUpdatedVisibleColumns());
-  }, []);
+  }, [getUpdatedVisibleColumns]);
 
   const displayLoadingSpinner = !isVisible ? (
     <>
@@ -91,8 +82,6 @@ function QueryDataGrid(props: QueryDataGridProps) {
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         rowCount={rowCount}
         renderCellValue={renderCellValue}
-        inMemory={{ level: 'sorting' }}
-        sorting={{ columns: sortingColumns, onSort }}
         pagination={{
           ...pagination,
           pageSizeOptions: [10, 20, 50],


### PR DESCRIPTION
### Description
The EuiDataGrid has performance issue when the result size is larger than 5000, disable sorting props to resolve the issue.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
