### PR TITLE
Use sampling method for PPL paragraph to have 100 result

### DIFF
--- a/public/components/notebooks/components/paragraph_components/ppl/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/ppl/index.tsx
@@ -136,22 +136,7 @@ export const PPLParagraph = ({
       <EuiSpacer size="s" />
       <EuiCompressedFormRow
         fullWidth={true}
-        helpText={
-          <EuiText size="s">
-            Supported languages include{' '}
-            {
-              <>
-                <EuiLink href={SQL_DOCUMENTATION_URL} target="_blank">
-                  SQL
-                </EuiLink>{' '}
-                <EuiLink href={PPL_DOCUMENTATION_URL} target="_blank">
-                  PPL
-                </EuiLink>{' '}
-              </>
-            }
-            .
-          </EuiText>
-        }
+        helpText={<EuiSpacer size="s" />}
         isInvalid={!!error}
         error={
           <EuiText size="s">

--- a/public/paragraphs/ppl.ts
+++ b/public/paragraphs/ppl.ts
@@ -12,7 +12,7 @@ import {
 import { ParagraphRegistryItem } from '../services/paragraph_service';
 import { callOpenSearchCluster } from '../plugin_helpers/plugin_proxy_call';
 import { getClient, getNotifications } from '../services';
-import { executePPLQueryWithHeadFilter } from '../../public/utils/query';
+import { executePPLQueryWithSampling } from '../../public/utils/query';
 import { parsePPLQuery } from '../../common/utils';
 import { addTimeRangeFilter } from '../utils/time';
 
@@ -44,7 +44,7 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               }),
             },
           })
-        : executePPLQueryWithHeadFilter({
+        : executePPLQueryWithSampling({
             http: getClient(),
             dataSourceId: dataSourceMDSId,
             query,
@@ -114,7 +114,7 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               }),
             },
           })
-        : executePPLQueryWithHeadFilter({
+        : executePPLQueryWithSampling({
             http: getClient(),
             dataSourceId: paragraphValue.dataSourceMDSId,
             query: addTimeRangeFilter(currentSearchQuery, queryParams),

--- a/public/utils/query.ts
+++ b/public/utils/query.ts
@@ -3,31 +3,84 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PPL_ENDPOINT } from '../../common/constants/shared';
 import { HttpSetup } from '../../../../src/core/public';
 import { callOpenSearchCluster } from '../../public/plugin_helpers/plugin_proxy_call';
 
-export const addHeadFilter = (query: string) => {
-  return `${query} | sort - _id | head 100`;
+/**
+ * The size that query result should always be sampling to
+ *
+ * TODO: adjust this size if required
+ */
+const QUERY_RESULT_SAMPLE_SIZE = 100;
+
+const SAMPLING_THRESHOLD = 0.01;
+
+/**
+ * Random sampling mechanism that generates a threshold score to filter query results:
+ *
+ * Formula: score = 1 - (target_size / total_count) - buffer
+ *
+ * Examples:
+ * - Count: 1000 → Score: 0.89 → Keeps ~11% of records → ~110 samples → head 100
+ * - Count: 400 → Score: 0.74 → Keeps ~26% of records → ~104 samples → head 100
+ *
+ * The buffer (0.01) ensures we get slightly more than the target size to account for
+ * randomness, then `head 100` guarantees exactly 100 results.
+ */
+export const addSamplingFilter = (query: string, count: number): string => {
+  const score = Math.max(
+    0,
+    parseFloat((1 - QUERY_RESULT_SAMPLE_SIZE / count - SAMPLING_THRESHOLD).toFixed(2))
+  );
+  return `${query} | eval random_score=rand() | where random_score > ${score} | head ${QUERY_RESULT_SAMPLE_SIZE}`;
 };
 
-export const executePPLQueryWithHeadFilter = async ({
-  http,
-  dataSourceId,
-  query,
-}: {
+interface PPLQueryParams {
   http: HttpSetup;
-  dataSourceId: string | undefined;
+  dataSourceId?: string;
   query: string;
-}) => {
+}
+
+const executePPLQuery = (params: PPLQueryParams, query: string) => {
   return callOpenSearchCluster({
-    http,
-    dataSourceId,
+    http: params.http,
+    dataSourceId: params.dataSourceId,
     request: {
-      path: `/_plugins/_ppl`,
+      path: PPL_ENDPOINT,
       method: 'POST',
-      body: JSON.stringify({
-        query: addHeadFilter(query),
-      }),
+      body: JSON.stringify({ query }),
     },
   });
+};
+
+export const executePPLQueryWithSampling = async (params: PPLQueryParams) => {
+  const { query } = params;
+
+  // Skip count check if query already has count aggregation to avoid conflicts
+  if (query.toLowerCase().includes('stats count()')) {
+    return executePPLQuery(params, `${query} | head ${QUERY_RESULT_SAMPLE_SIZE}`);
+  }
+
+  try {
+    const countResponse = await executePPLQuery(params, `${query} | stats count()`);
+    const count = countResponse?.datarows?.[0]?.[0];
+
+    if (count === 0) {
+      // No need to execute another PPL query as the result is empty anyway
+      return {
+        datarows: [],
+      };
+    }
+
+    const finalQuery =
+      count > QUERY_RESULT_SAMPLE_SIZE
+        ? addSamplingFilter(query, count)
+        : `${query} | head ${QUERY_RESULT_SAMPLE_SIZE}`;
+
+    return executePPLQuery(params, finalQuery);
+  } catch (error) {
+    // Fallback to simple head limit if count query fails
+    return executePPLQuery(params, `${query} | head ${QUERY_RESULT_SAMPLE_SIZE}`);
+  }
 };


### PR DESCRIPTION
### Description
Always sample to 100 no matter the query result count, and no sampling if the result count is below 100. The sampling method we choose is random sampling across the entire query result. The sample size has been set to 100 for simplicity and we can also adjust it or implement dynamic sample size changes in the future.

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
