### PR TITLE
Use default data source for input panel

### DIFF
--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -94,7 +94,7 @@ export const InputProvider: React.FC<InputProviderProps> = ({
   children,
   onSubmit,
   input,
-  dataSourceId = '',
+  dataSourceId = undefined,
   aiFeatureEnabled,
 }) => {
   const [currInputType, setCurrInputType] = useState<InputType>(

--- a/public/components/notebooks/components/input/multi_variant_input.tsx
+++ b/public/components/notebooks/components/input/multi_variant_input.tsx
@@ -120,7 +120,7 @@ export const MultiVariantInput: React.FC<MultiVariantInputProps> = (props) => {
     <InputProvider
       onSubmit={props.onSubmit}
       input={props.input}
-      dataSourceId={props.dataSourceId || ''}
+      dataSourceId={props.dataSourceId || undefined}
       aiFeatureEnabled={props.aiFeatureEnabled}
     >
       <MultiVariantInputContent actionDisabled={props.actionDisabled} />

--- a/public/components/notebooks/components/input/query_panel/query_panel.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel.tsx
@@ -240,7 +240,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
         componentConfig={{
           savedObjects: savedObjects.client,
           notifications,
-          activeOption: [{ id: localDataSourceId || '' }],
+          activeOption: localDataSourceId !== undefined ? [{ id: localDataSourceId }] : [],
           onSelectedDataSources: (ds: DataSourceOption[]) => {
             setLocalDataSourceId(ds[0].id);
           },

--- a/public/components/notebooks/components/input_panel.tsx
+++ b/public/components/notebooks/components/input_panel.tsx
@@ -94,7 +94,7 @@ export const InputPanel: React.FC<InputPanelProps> = ({ onParagraphCreated }) =>
       <EuiPanel grow borderRadius="xl" hasBorder hasShadow paddingSize="s">
         <MultiVariantInput
           onSubmit={handleCreateParagraph}
-          dataSourceId={notebookType === NotebookType.CLASSIC ? '' : notebookDataSourceId}
+          dataSourceId={notebookType === NotebookType.CLASSIC ? undefined : notebookDataSourceId}
           aiFeatureEnabled={application?.capabilities.investigation.agenticFeaturesEnabled}
         />
       </EuiPanel>


### PR DESCRIPTION
### Description
Use default data source in query editor inside input panel instead of using local cluster to fix the issue when the local cluster is not available. 

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
