### PR TITLE
Use default data source for input panel and remove sampling for classic notebook

### DIFF
--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -94,7 +94,7 @@ export const InputProvider: React.FC<InputProviderProps> = ({
   children,
   onSubmit,
   input,
-  dataSourceId = undefined,
+  dataSourceId,
   aiFeatureEnabled,
 }) => {
   const [currInputType, setCurrInputType] = useState<InputType>(

--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -94,7 +94,7 @@ export const InputProvider: React.FC<InputProviderProps> = ({
   children,
   onSubmit,
   input,
-  dataSourceId = '',
+  dataSourceId = undefined,
   aiFeatureEnabled,
 }) => {
   const [currInputType, setCurrInputType] = useState<InputType>(

--- a/public/components/notebooks/components/input/multi_variant_input.tsx
+++ b/public/components/notebooks/components/input/multi_variant_input.tsx
@@ -120,7 +120,7 @@ export const MultiVariantInput: React.FC<MultiVariantInputProps> = (props) => {
     <InputProvider
       onSubmit={props.onSubmit}
       input={props.input}
-      dataSourceId={props.dataSourceId || ''}
+      dataSourceId={props.dataSourceId}
       aiFeatureEnabled={props.aiFeatureEnabled}
     >
       <MultiVariantInputContent actionDisabled={props.actionDisabled} />

--- a/public/components/notebooks/components/input/query_panel/query_panel.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel.tsx
@@ -241,7 +241,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
         componentConfig={{
           savedObjects: savedObjects.client,
           notifications,
-          activeOption: [{ id: localDataSourceId || '' }],
+          activeOption: localDataSourceId !== undefined ? [{ id: localDataSourceId }] : [],
           onSelectedDataSources: (ds: DataSourceOption[]) => {
             setLocalDataSourceId(ds[0].id);
           },

--- a/public/components/notebooks/components/input_panel.tsx
+++ b/public/components/notebooks/components/input_panel.tsx
@@ -94,7 +94,7 @@ export const InputPanel: React.FC<InputPanelProps> = ({ onParagraphCreated }) =>
       <EuiPanel grow borderRadius="xl" hasBorder hasShadow paddingSize="s">
         <MultiVariantInput
           onSubmit={handleCreateParagraph}
-          dataSourceId={notebookType === NotebookType.CLASSIC ? '' : notebookDataSourceId}
+          dataSourceId={notebookType === NotebookType.CLASSIC ? undefined : notebookDataSourceId}
           aiFeatureEnabled={application?.capabilities.investigation.agenticFeaturesEnabled}
         />
       </EuiPanel>

--- a/public/paragraphs/ppl.ts
+++ b/public/paragraphs/ppl.ts
@@ -12,9 +12,10 @@ import {
 import { ParagraphRegistryItem } from '../services/paragraph_service';
 import { callOpenSearchCluster } from '../plugin_helpers/plugin_proxy_call';
 import { getClient, getNotifications } from '../services';
-import { executePPLQueryWithSampling } from '../../public/utils/query';
+import { executePPLQuery } from '../../public/utils/query';
 import { parsePPLQuery } from '../../common/utils';
 import { addTimeRangeFilter } from '../utils/time';
+import { NotebookType } from '../../common/types/notebooks';
 
 export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObject> = {
   ParagraphComponent: PPLParagraph,
@@ -44,11 +45,14 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               }),
             },
           })
-        : executePPLQueryWithSampling({
-            http: getClient(),
-            dataSourceId: dataSourceMDSId,
-            query,
-          }));
+        : executePPLQuery(
+            {
+              http: getClient(),
+              dataSourceId: dataSourceMDSId,
+              query,
+            },
+            NotebookType.AGENTIC
+          ));
 
       if (!queryObject || queryObject.error) {
         return '';
@@ -73,12 +77,14 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
           \`\`\`
         `;
   },
-  runParagraph: async ({ paragraphState, saveParagraph }) => {
+  runParagraph: async ({ paragraphState, saveParagraph, notebookStateValue }) => {
     const paragraphValue = paragraphState.getBackendValue();
     const inputText = paragraphValue.input.inputText;
     const queryType = inputText.substring(0, 4) === '%sql' ? '_sql' : '_ppl';
     const queryParams = paragraphValue.input.parameters as any;
     const inputQuery = queryParams?.query || inputText.substring(5);
+    const { notebookType } = notebookStateValue.context.value;
+
     if (isEmpty(inputQuery)) {
       return;
     }
@@ -114,11 +120,14 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               }),
             },
           })
-        : executePPLQueryWithSampling({
-            http: getClient(),
-            dataSourceId: paragraphValue.dataSourceMDSId,
-            query: addTimeRangeFilter(currentSearchQuery, queryParams),
-          }));
+        : executePPLQuery(
+            {
+              http: getClient(),
+              dataSourceId: paragraphValue.dataSourceMDSId,
+              query: addTimeRangeFilter(currentSearchQuery, queryParams),
+            },
+            notebookType ?? NotebookType.CLASSIC
+          ));
 
       paragraphState.updateFullfilledOutput(queryResponse);
       paragraphState.updateUIState({

--- a/public/paragraphs/ppl.ts
+++ b/public/paragraphs/ppl.ts
@@ -51,7 +51,7 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               dataSourceId: dataSourceMDSId,
               query,
             },
-            NotebookType.AGENTIC
+            true
           ));
 
       if (!queryObject || queryObject.error) {
@@ -126,7 +126,7 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
               dataSourceId: paragraphValue.dataSourceMDSId,
               query: addTimeRangeFilter(currentSearchQuery, queryParams),
             },
-            notebookType ?? NotebookType.CLASSIC
+            notebookType === NotebookType.AGENTIC
           ));
 
       paragraphState.updateFullfilledOutput(queryResponse);

--- a/public/utils/__tests__/query.test.ts
+++ b/public/utils/__tests__/query.test.ts
@@ -5,7 +5,6 @@
 
 import { addSamplingFilter, executePPLQuery, removeRandomScoreFromResponse } from '../query';
 import { callOpenSearchCluster } from '../../plugin_helpers/plugin_proxy_call';
-import { NotebookType } from '../../../common/types/notebooks';
 
 jest.mock('../../plugin_helpers/plugin_proxy_call');
 const mockCallOpenSearchCluster = callOpenSearchCluster as jest.MockedFunction<
@@ -65,7 +64,7 @@ describe('Query Utils', () => {
         query: 'source=logs',
       };
 
-      await executePPLQuery(params, NotebookType.AGENTIC);
+      await executePPLQuery(params, true);
 
       expect(mockCallOpenSearchCluster).toHaveBeenCalledTimes(2);
       expect(mockCallOpenSearchCluster).toHaveBeenLastCalledWith({
@@ -93,7 +92,7 @@ describe('Query Utils', () => {
         query: 'source=logs',
       };
 
-      await executePPLQuery(params, NotebookType.AGENTIC);
+      await executePPLQuery(params, true);
 
       expect(mockCallOpenSearchCluster).toHaveBeenLastCalledWith({
         http: mockHttp,
@@ -118,7 +117,7 @@ describe('Query Utils', () => {
         query: 'source=logs | stats count()',
       };
 
-      await executePPLQuery(params, NotebookType.AGENTIC);
+      await executePPLQuery(params, true);
 
       expect(mockCallOpenSearchCluster).toHaveBeenCalledTimes(1);
       expect(mockCallOpenSearchCluster).toHaveBeenCalledWith({
@@ -146,7 +145,7 @@ describe('Query Utils', () => {
         query: 'source=logs',
       };
 
-      await executePPLQuery(params, NotebookType.AGENTIC);
+      await executePPLQuery(params, true);
 
       expect(mockCallOpenSearchCluster).toHaveBeenCalledTimes(2);
       expect(mockCallOpenSearchCluster).toHaveBeenLastCalledWith({
@@ -170,7 +169,7 @@ describe('Query Utils', () => {
         query: 'source=logs',
       };
 
-      await executePPLQuery(params, NotebookType.CLASSIC);
+      await executePPLQuery(params, false);
 
       expect(mockCallOpenSearchCluster).toHaveBeenCalledTimes(1);
       expect(mockCallOpenSearchCluster).toHaveBeenCalledWith({

--- a/public/utils/query.ts
+++ b/public/utils/query.ts
@@ -6,7 +6,6 @@
 import { PPL_ENDPOINT } from '../../common/constants/shared';
 import { HttpSetup } from '../../../../src/core/public';
 import { callOpenSearchCluster } from '../../public/plugin_helpers/plugin_proxy_call';
-import { NotebookType } from '../../common/types/notebooks';
 
 /**
  * The size that query result should always be sampling to
@@ -68,11 +67,11 @@ const callClusterWithPPlQuery = (params: PPLQueryParams, query: string) => {
   });
 };
 
-export const executePPLQuery = async (params: PPLQueryParams, notebookType: NotebookType) => {
+export const executePPLQuery = async (params: PPLQueryParams, shouldSampling: boolean) => {
   const { query } = params;
 
   // No need sampling for classic notebook
-  if (notebookType === NotebookType.CLASSIC) {
+  if (!shouldSampling) {
     return callClusterWithPPlQuery(params, query);
   }
 


### PR DESCRIPTION
### Description
Use default data source in query editor inside input panel instead of using local cluster to fix the issue when the local cluster is not available.

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
