### PR TITLE
Fix the query editor back to default state when run the query

### DIFF
--- a/public/components/notebooks/components/input/input_context.tsx
+++ b/public/components/notebooks/components/input/input_context.tsx
@@ -77,7 +77,6 @@ interface InputContextValue<T extends InputType = InputType> {
 
   // For query editor
   editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
-  editorTextRef: React.MutableRefObject<string>;
 }
 
 const InputContext = createContext<InputContextValue | undefined>(undefined);
@@ -119,7 +118,6 @@ export const InputProvider: React.FC<InputProviderProps> = ({
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const editorTextRef = useRef(input?.inputText ? input?.inputText : '');
 
   const handleInputChange = useCallback((value: Partial<InputValueType<typeof currInputType>>) => {
     if (typeof value === 'object') {
@@ -254,7 +252,6 @@ export const InputProvider: React.FC<InputProviderProps> = ({
     isParagraphSelectionOpen,
     textareaRef,
     editorRef,
-    editorTextRef,
     isLoading,
     isInputMountedInParagraph,
     paragraphOptions,

--- a/public/components/notebooks/components/input/query_panel/index_selector.tsx/index_selector.tsx
+++ b/public/components/notebooks/components/input/query_panel/index_selector.tsx/index_selector.tsx
@@ -125,6 +125,8 @@ export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ 
         selectedIndex: { label: indexTitle },
         selectedTimeField: { label: timeField },
       }));
+    } else {
+      setCurrentSelection(INITAL_INDEX_SELECTION);
     }
   }, [selectedIndex]);
 

--- a/public/components/notebooks/components/input/query_panel/index_selector.tsx/index_selector.tsx
+++ b/public/components/notebooks/components/input/query_panel/index_selector.tsx/index_selector.tsx
@@ -36,7 +36,7 @@ interface IndexSelectorOption {
 }
 
 export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ dataSourceId }) => {
-  const { handleInputChange, inputValue, editorTextRef } = useInputContext();
+  const { handleInputChange, inputValue } = useInputContext();
   const { noDatePicker, selectedIndex } = (inputValue as QueryState) || {};
   const {
     services: {
@@ -79,12 +79,9 @@ export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ 
         stage: 'index',
         isLoading: false,
       });
-      if (previousDataSouce.current !== undefined) {
-        handleInputChange(DEFAULT_QUERY_STATE);
-        editorTextRef.current = '';
-      }
+      handleInputChange(DEFAULT_QUERY_STATE);
     }
-  }, [dataSourceId, handleInputChange, editorTextRef]);
+  }, [dataSourceId, handleInputChange]);
 
   useEffect(() => {
     // TODO: consider to move the check for indices to notebook context
@@ -183,7 +180,6 @@ export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ 
           setUiState((prev) => ({ ...prev, isOpen: false }));
 
           handleInputChange(DEFAULT_QUERY_STATE);
-          editorTextRef.current = '';
 
           try {
             const res = await indexPatterns.getFieldsForWildcard({
@@ -206,7 +202,7 @@ export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ 
         }
       }
     },
-    [noDatePicker, indexPatterns, dataSourceId, handleInputChange, fetchTimeFields, editorTextRef]
+    [noDatePicker, indexPatterns, dataSourceId, handleInputChange, fetchTimeFields]
   );
 
   const handleTimeFieldChange = useCallback(
@@ -225,10 +221,9 @@ export const IndexSelector: React.FC<{ dataSourceId: string | undefined }> = ({ 
         timeField: selected?.label,
       };
 
-      editorTextRef.current = '';
       handleInputChange({ ...DEFAULT_QUERY_STATE, selectedIndex: indexData });
     },
-    [indicesData.allFields, handleInputChange, editorTextRef]
+    [indicesData.allFields, handleInputChange]
   );
 
   const handleBack = () => {

--- a/public/components/notebooks/components/input/query_panel/language_toggle/language_toggle.tsx
+++ b/public/components/notebooks/components/input/query_panel/language_toggle/language_toggle.tsx
@@ -17,7 +17,6 @@ export const LanguageToggle: React.FC<{ promptModeIsAvailable: boolean }> = ({
   const {
     inputValue,
     isAgenticNotebook,
-    editorTextRef,
     handleInputChange,
     handleSetCurrInputType,
   } = useInputContext();
@@ -42,13 +41,12 @@ export const LanguageToggle: React.FC<{ promptModeIsAvailable: boolean }> = ({
         queryLanguage: actualLanguage,
         isPromptEditorMode: isAI,
       });
-      editorTextRef.current = '';
 
       if (!isAI) {
         handleSetCurrInputType(actualLanguage);
       }
     },
-    [closePopover, handleInputChange, handleSetCurrInputType, editorTextRef]
+    [closePopover, handleInputChange, handleSetCurrInputType]
   );
 
   const badgeLabel = isPromptEditorMode ? 'AI' : queryLanguage || 'PPL';

--- a/public/components/notebooks/components/input/query_panel/language_toggle/language_toggle.tsx
+++ b/public/components/notebooks/components/input/query_panel/language_toggle/language_toggle.tsx
@@ -17,6 +17,7 @@ export const LanguageToggle: React.FC<{ promptModeIsAvailable: boolean }> = ({
   const {
     inputValue,
     isAgenticNotebook,
+    editorTextRef,
     handleInputChange,
     handleSetCurrInputType,
   } = useInputContext();
@@ -41,12 +42,13 @@ export const LanguageToggle: React.FC<{ promptModeIsAvailable: boolean }> = ({
         queryLanguage: actualLanguage,
         isPromptEditorMode: isAI,
       });
+      editorTextRef.current = '';
 
       if (!isAI) {
         handleSetCurrInputType(actualLanguage);
       }
     },
-    [closePopover, handleInputChange, handleSetCurrInputType]
+    [closePopover, handleInputChange, handleSetCurrInputType, editorTextRef]
   );
 
   const badgeLabel = isPromptEditorMode ? 'AI' : queryLanguage || 'PPL';

--- a/public/components/notebooks/components/input/query_panel/query_panel.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel.tsx
@@ -150,10 +150,19 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
         }
       } else if (typeof inputValue === 'string' || isEmpty(inputValue)) {
         handleInputChange(QUERY_PANEL_INITIAL_STATE);
+        editorTextRef.current = '';
       }
     };
     handleInitalInput();
-  }, [paragraphInput, handleInputChange, indexPatterns, localDataSourceId, inputValue, isFetching]);
+  }, [
+    paragraphInput,
+    handleInputChange,
+    indexPatterns,
+    localDataSourceId,
+    inputValue,
+    isFetching,
+    editorTextRef,
+  ]);
 
   const handleTimeChange = useCallback(
     (props) => {
@@ -191,6 +200,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
       return query;
     } catch (err) {
       console.log(`Text2ppl error: ${err}`);
+      throw err;
     } finally {
       setIsFetching(false);
     }
@@ -206,8 +216,10 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
 
   const handleRunQuery = useCallback(async () => {
     const defaultQuery = selectedIndex?.title ? `source = ${selectedIndex?.title}` : '';
+    const queryToExecute = editorTextRef.current || defaultQuery;
+    handleInputChange({ value: queryToExecute });
     handleSubmit(
-      editorTextRef.current || defaultQuery,
+      queryToExecute,
       {
         timeRange,
         indexName: selectedIndex?.title,
@@ -220,6 +232,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
   }, [
     handleSubmit,
     handleGenerateQuery,
+    handleInputChange,
     editorTextRef,
     isPromptEditorMode,
     noDatePicker,

--- a/public/components/notebooks/components/input/query_panel/query_panel.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel.tsx
@@ -71,7 +71,6 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
     },
   } = useOpenSearchDashboards<NoteBookServices>();
   const {
-    editorTextRef,
     inputValue,
     dataSourceId,
     isLoading,
@@ -95,7 +94,14 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
   const queryState = (inputValue && typeof inputValue !== 'string'
     ? inputValue
     : QUERY_PANEL_INITIAL_STATE) as QueryState;
-  const { queryLanguage, isPromptEditorMode, selectedIndex, timeRange, noDatePicker } = queryState;
+  const {
+    value,
+    queryLanguage,
+    isPromptEditorMode,
+    selectedIndex,
+    timeRange,
+    noDatePicker,
+  } = queryState;
 
   useEffect(() => {
     // TODO: consider move this to global state
@@ -113,7 +119,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
         // Set up input value from paragraph input
         try {
           setIsFetching(true);
-          const value = paragraphInput.inputText;
+          const val = paragraphInput.inputText;
           const {
             timeRange: inputTimeRange,
             query,
@@ -130,7 +136,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
             : [];
 
           handleInputChange({
-            value,
+            value: val,
             query,
             queryLanguage: paragraphInput.inputType as QueryLanguage,
             // If question is defined, indicate the user executed t2ppl previously
@@ -150,19 +156,10 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
         }
       } else if (typeof inputValue === 'string' || isEmpty(inputValue)) {
         handleInputChange(QUERY_PANEL_INITIAL_STATE);
-        editorTextRef.current = '';
       }
     };
     handleInitalInput();
-  }, [
-    paragraphInput,
-    handleInputChange,
-    indexPatterns,
-    localDataSourceId,
-    inputValue,
-    isFetching,
-    editorTextRef,
-  ]);
+  }, [paragraphInput, handleInputChange, indexPatterns, localDataSourceId, inputValue, isFetching]);
 
   const handleTimeChange = useCallback(
     (props) => {
@@ -172,16 +169,13 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
   );
 
   const handleGenerateQuery = useCallback(async () => {
-    if (
-      paragraphInput?.inputText &&
-      editorTextRef.current === (paragraphInput?.parameters as any)?.question
-    ) {
+    if (paragraphInput?.inputText && value === (paragraphInput?.parameters as any)?.question) {
       // Don't regenerate PPL query if the input NL question isn't changed
       return paragraphInput?.inputText;
     }
     setIsFetching(true);
     const params: QueryAssistParameters = {
-      question: editorTextRef.current,
+      question: value,
       index: selectedIndex.title,
       language: queryLanguage,
       dataSourceId: localDataSourceId,
@@ -206,7 +200,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
     }
   }, [
     paragraphInput,
-    editorTextRef,
+    value,
     selectedIndex.title,
     queryLanguage,
     localDataSourceId,
@@ -216,7 +210,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
 
   const handleRunQuery = useCallback(async () => {
     const defaultQuery = selectedIndex?.title ? `source = ${selectedIndex?.title}` : '';
-    const queryToExecute = editorTextRef.current || defaultQuery;
+    const queryToExecute = value || defaultQuery;
     handleInputChange({ value: queryToExecute });
     handleSubmit(
       queryToExecute,
@@ -233,7 +227,7 @@ export const QueryPanel: React.FC<QueryPanelProps> = ({
     handleSubmit,
     handleGenerateQuery,
     handleInputChange,
-    editorTextRef,
+    value,
     isPromptEditorMode,
     noDatePicker,
     selectedIndex,

--- a/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
@@ -31,8 +31,13 @@ export const QueryPanelEditor: React.FC<{
   const [showPlaceholder, setShowPlaceholder] = useState(false);
 
   useEffect(() => {
-    setShowPlaceholder(!editorTextRef.current.length);
-  }, [editorTextRef]);
+    const shouldShow = !editorTextRef.current.length;
+    if (showPlaceholder !== shouldShow) {
+      setShowPlaceholder(shouldShow);
+    }
+    // When set the editorTextRef.current to empty string, we want setShowPlaceholder to true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorTextRef.current, showPlaceholder]);
 
   useEffect(() => {
     selectedIndexRef.current = selectedIndex;

--- a/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
+++ b/public/components/notebooks/components/input/query_panel/query_panel_editor.tsx
@@ -22,7 +22,7 @@ export const QueryPanelEditor: React.FC<{
   handleRunQuery: () => void;
 }> = ({ queryState, handleRunQuery, promptModeIsAvailable }) => {
   const { services } = useOpenSearchDashboards<NoteBookServices>();
-  const { editorRef, editorTextRef, handleInputChange } = useInputContext();
+  const { editorRef, handleInputChange } = useInputContext();
 
   const { value, queryLanguage, isPromptEditorMode, selectedIndex } = queryState;
 
@@ -31,13 +31,11 @@ export const QueryPanelEditor: React.FC<{
   const [showPlaceholder, setShowPlaceholder] = useState(false);
 
   useEffect(() => {
-    const shouldShow = !editorTextRef.current.length;
+    const shouldShow = !value.length;
     if (showPlaceholder !== shouldShow) {
       setShowPlaceholder(shouldShow);
     }
-    // When set the editorTextRef.current to empty string, we want setShowPlaceholder to true
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorTextRef.current, showPlaceholder]);
+  }, [value, showPlaceholder]);
 
   useEffect(() => {
     selectedIndexRef.current = selectedIndex;
@@ -54,7 +52,7 @@ export const QueryPanelEditor: React.FC<{
     promptModeIsAvailable: queryLanguage === 'SQL' ? false : promptModeIsAvailable,
     isPromptEditorMode,
     queryLanguage,
-    userQueryString: value || '',
+    editorTextValue: value || '',
     handleRun: handleRunQuery,
     handleEscape: useCallback(() => {
       handleInputChange({ isPromptEditorMode: false, query: '' });
@@ -63,12 +61,11 @@ export const QueryPanelEditor: React.FC<{
       handleInputChange({ isPromptEditorMode: true });
     }, [handleInputChange]),
     handleChange: (val) => {
-      setShowPlaceholder(!val.length);
+      handleInputChange({ value: val });
     },
     isQueryEditorDirty: false,
     services,
     editorRef,
-    editorTextRef,
     selectedIndexRef,
   });
   return (
@@ -83,7 +80,7 @@ export const QueryPanelEditor: React.FC<{
       data-test-subj="notebookQueryPanelEditor"
       onClick={onEditorClick}
     >
-      <CodeEditor {...editorProps} />
+      <CodeEditor value={value} {...editorProps} />
       {showPlaceholder ? (
         <div className={`notebookQueryPanelEditor__placeholder`}>{placeholder}</div>
       ) : null}

--- a/public/components/notebooks/components/input/query_panel/use_query_panel_editor/use_query_panel_editor.ts
+++ b/public/components/notebooks/components/input/query_panel/use_query_panel_editor/use_query_panel_editor.ts
@@ -107,12 +107,11 @@ interface UseQueryPanelEditorProps {
   promptModeIsAvailable: boolean;
   isPromptEditorMode: boolean;
   queryLanguage: string;
-  userQueryString: string;
+  editorTextValue: string;
   handleRun: () => void;
   handleEscape: () => void;
   handleSpaceBar: () => void;
   handleChange: (value: string) => void;
-  editorTextRef: React.MutableRefObject<string>;
   editorRef: React.MutableRefObject<IStandaloneCodeEditor | null>;
   selectedIndexRef: React.MutableRefObject<QueryIndexState>;
   isQueryEditorDirty: boolean;
@@ -130,7 +129,6 @@ export interface UseQueryPanelEditorReturnType {
   placeholder: string;
   promptIsTyping: boolean;
   useLatestTheme: true;
-  value: string;
 }
 
 export const useQueryPanelEditor = ({
@@ -138,12 +136,11 @@ export const useQueryPanelEditor = ({
   promptModeIsAvailable,
   isPromptEditorMode: isPromptMode,
   queryLanguage,
-  userQueryString,
+  editorTextValue,
   handleRun,
   handleEscape,
   handleSpaceBar,
   handleChange,
-  editorTextRef,
   editorRef,
   selectedIndexRef,
   isQueryEditorDirty,
@@ -155,19 +152,26 @@ export const useQueryPanelEditor = ({
   const promptModeIsAvailableRef = useRef(promptModeIsAvailable);
   const handleRunRef = useRef(handleRun);
   const completionProviderRef = useRef<monaco.IDisposable>();
+  const editorTextRef = useRef(editorTextValue);
 
   // Keep the refs updated with latest context
   useEffect(() => {
-    editorTextRef.current = userQueryString;
+    editorTextRef.current = editorTextValue;
+  }, [editorTextValue]);
+  useEffect(() => {
     isPromptModeRef.current = isPromptMode;
+  }, [isPromptMode]);
+  useEffect(() => {
     promptModeIsAvailableRef.current = promptModeIsAvailable;
+  }, [promptModeIsAvailable]);
+  useEffect(() => {
     handleRunRef.current = handleRun;
-  }, [isPromptMode, promptModeIsAvailable, handleRun, userQueryString, editorTextRef]);
+  }, [handleRun]);
 
   // The 'triggerSuggestOnFocus' prop of CodeEditor only happens on mount, so I am intentionally not passing it
   // and programmatically doing it here. We should only trigger autosuggestion on focus while on isQueryMode and there is text
   useEffect(() => {
-    if (isQueryMode && !!editorTextRef.current.length) {
+    if (isQueryMode && !!editorTextValue.length) {
       const onDidFocusDisposable = editorRef.current?.onDidFocusEditorWidget(() => {
         editorRef.current?.trigger('keyboard', 'editor.action.triggerSuggest', {});
       });
@@ -176,7 +180,7 @@ export const useQueryPanelEditor = ({
         onDidFocusDisposable?.dispose();
       };
     }
-  }, [isQueryMode, editorRef, editorTextRef]);
+  }, [isQueryMode, editorRef, editorTextValue]);
 
   const setEditorRef = useCallback(
     (editor: IStandaloneCodeEditor) => {
@@ -325,7 +329,7 @@ export const useQueryPanelEditor = ({
         return editor;
       };
     },
-    [setEditorRef, handleEscape, setEditorIsFocused, editorTextRef, handleSpaceBar]
+    [setEditorRef, handleEscape, setEditorIsFocused, handleSpaceBar]
   );
 
   const options = useMemo(() => (isQueryMode ? queryEditorOptions : promptEditorOptions), [
@@ -350,11 +354,10 @@ export const useQueryPanelEditor = ({
 
   const onChange = useCallback(
     (newText: string) => {
-      editorTextRef.current = newText;
       if (!isQueryEditorDirty) handleChange(newText);
       if (isPromptMode) handleChangeForPromptIsTyping();
     },
-    [isPromptMode, handleChangeForPromptIsTyping, isQueryEditorDirty, handleChange, editorTextRef]
+    [isPromptMode, handleChangeForPromptIsTyping, isQueryEditorDirty, handleChange]
   );
 
   return {
@@ -369,6 +372,5 @@ export const useQueryPanelEditor = ({
     placeholder,
     promptIsTyping,
     useLatestTheme: true,
-    value: editorTextRef.current,
   };
 };

--- a/public/components/notebooks/components/input/query_panel/use_query_panel_editor/use_query_panel_editor.ts
+++ b/public/components/notebooks/components/input/query_panel/use_query_panel_editor/use_query_panel_editor.ts
@@ -158,10 +158,11 @@ export const useQueryPanelEditor = ({
 
   // Keep the refs updated with latest context
   useEffect(() => {
+    editorTextRef.current = userQueryString;
     isPromptModeRef.current = isPromptMode;
     promptModeIsAvailableRef.current = promptModeIsAvailable;
     handleRunRef.current = handleRun;
-  }, [isPromptMode, promptModeIsAvailable, handleRun, userQueryString]);
+  }, [isPromptMode, promptModeIsAvailable, handleRun, userQueryString, editorTextRef]);
 
   // The 'triggerSuggestOnFocus' prop of CodeEditor only happens on mount, so I am intentionally not passing it
   // and programmatically doing it here. We should only trigger autosuggestion on focus while on isQueryMode and there is text


### PR DESCRIPTION
### Description
 

### Issues Resolved
 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
