### PR TITLE
Use literal value for data source engine type to avoid lint error

### DIFF
--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -5,10 +5,7 @@
 
 import semver from 'semver';
 import { SavedObject } from '../../../../src/core/public';
-import {
-  DataSourceAttributes,
-  DataSourceEngineType,
-} from '../../../../src/plugins/data_source/common/data_sources';
+import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 import * as pluginManifest from '../../opensearch_dashboards.json';
 
 /**
@@ -26,8 +23,8 @@ export function get<T = unknown>(obj: Record<string, any>, path: string, default
 export const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>) => {
   const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
   const installedPlugins = dataSource?.attributes?.installedPlugins || [];
-  const isServerless =
-    dataSource.attributes.dataSourceEngineType === DataSourceEngineType.OpenSearchServerless;
+  // Using DataSourceEngineType.opensearchServerless requires make data source as a required bundles of investigation.
+  const isServerless = dataSource.attributes.dataSourceEngineType === 'OpenSearch Serverless';
   return (
     isServerless ||
     (semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions) &&


### PR DESCRIPTION
### Description
Using DataSourceEngineType from data source plugin without making it a required bundles will throw lint error when compiling in dev mode. Change it to literal value.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
