### PR TITLE
feat: remove router info when cancel / close the create modal

### DIFF
--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -105,6 +105,7 @@ export function NoteTable({ deleteNotebook }: NoteTableProps) {
   }, [finalNotebooks.length, fetchNotebooks, chrome]);
 
   const closeModal = useCallback(() => {
+    window.location.assign('#/');
     setIsModalVisible(false);
   }, []);
   const showModal = () => {


### PR DESCRIPTION
### Description
Previously notebook table did not navigate users back to the router state without `#/create` so once user close the modal, they can never open the modal any more. This PR fix the issue by changing the router while close the modal.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
