### PR TITLE
fix: using parameterized query as final query

### DIFF
--- a/public/components/notebooks/components/paragraph_components/ppl/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/ppl/index.tsx
@@ -117,12 +117,16 @@ export const PPLParagraph = ({
     [paragraphValue.input.inputText]
   );
 
+  const outputQuery = useMemo(() => ParagraphState.getOutput(paragraphValue)?.result, [
+    paragraphValue,
+  ]);
+
   const inputQueryWithTimeFilter = useMemo(() => {
     const params = paragraphValue.input.parameters as any;
     return paragraphValue.input.inputText.startsWith('%sql')
       ? inputQuery
-      : params?.query || addTimeRangeFilter(inputQuery, params);
-  }, [inputQuery, paragraphValue.input.parameters, paragraphValue.input.inputText]);
+      : params?.query || addTimeRangeFilter(outputQuery || inputQuery, params);
+  }, [inputQuery, paragraphValue.input.parameters, paragraphValue.input.inputText, outputQuery]);
 
   const columns = useMemo(() => createQueryColumns(queryObject?.schema || []), [
     queryObject?.schema,

--- a/public/paragraphs/ppl.ts
+++ b/public/paragraphs/ppl.ts
@@ -16,6 +16,7 @@ import { executePPLQuery, jsonArrayToTsv } from '../../public/utils/query';
 import { parsePPLQuery } from '../../common/utils';
 import { addTimeRangeFilter } from '../utils/time';
 import { NotebookType } from '../../common/types/notebooks';
+import { ParagraphState } from '../../common/state/paragraph_state';
 
 export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObject> = {
   ParagraphComponent: PPLParagraph,
@@ -25,7 +26,7 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
       return '';
     }
 
-    const query = input.inputText.substring(5);
+    const query = ParagraphState.getOutput(paragraph)?.result || input.inputText.substring(5);
     const isSqlQuery = input?.inputText.substring(0, 4) === '%sql';
     const queryType = isSqlQuery ? '_sql' : '_ppl';
     const queryTypeName = isSqlQuery ? 'SQL' : 'PPL';
@@ -82,7 +83,10 @@ export const PPLParagraphItem: ParagraphRegistryItem<string, unknown, QueryObjec
     const inputText = paragraphValue.input.inputText;
     const queryType = inputText.substring(0, 4) === '%sql' ? '_sql' : '_ppl';
     const queryParams = paragraphValue.input.parameters as any;
-    const inputQuery = queryParams?.query || inputText.substring(5);
+    const inputQuery =
+      ParagraphState.getOutput(paragraphValue)?.result ||
+      queryParams?.query ||
+      inputText.substring(5);
     const { notebookType } = notebookStateValue.context.value;
 
     if (isEmpty(inputQuery)) {


### PR DESCRIPTION
### Description
We introduced parameterized query previously but the refactored query paragraph does not honor the output as the final result. This PR mainly address the issue by using that value.

#### Before fix
<img width="2346" height="1388" alt="image" src="https://github.com/user-attachments/assets/38aed099-f17e-44be-9ff5-f5778426c045" />

#### After fix
<img width="1888" height="1446" alt="image" src="https://github.com/user-attachments/assets/57045bc2-fffb-4ad9-b3ef-c9bf16218e4b" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
