### PR TITLE
Add a modal to let the user choose rerun with/without existing hypothesis

### DIFF
--- a/public/components/notebooks/components/classic_notebook.tsx
+++ b/public/components/notebooks/components/classic_notebook.tsx
@@ -67,7 +67,7 @@ export function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
   );
   const isSavedObjectNotebook = isValidUUID(openedNoteId);
   const paraDivRefs = useRef<Array<HTMLDivElement | null>>([]);
-  const { createParagraph, deleteParagraph } = notebookContext.paragraphHooks;
+  const { createParagraph, deleteParagraph, runParagraph } = notebookContext.paragraphHooks;
 
   const showDeleteParaModal = (index: number) => {
     setModalLayout(
@@ -146,9 +146,18 @@ export function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
     }, 0);
   }, []);
 
-  const handleInputPanelParagraphCreated = useCallback(() => {
-    scrollToPara(paraDivRefs.current.length - 1);
-  }, [scrollToPara]);
+  const handleInputPanelParagraphCreated = useCallback(
+    (createParagraphRes) => {
+      scrollToPara(paraDivRefs.current.length - 1);
+
+      // FIXME run paragraph should handle by input
+      const paragraphStateValue = createParagraphRes?.value;
+      if (paragraphStateValue.input.inputType === 'MARKDOWN') {
+        runParagraph({ id: paragraphStateValue.id });
+      }
+    },
+    [scrollToPara, runParagraph]
+  );
 
   const loadNotebook = useCallback(() => {
     loadNotebookHook()
@@ -228,7 +237,6 @@ export function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
                 >
                   {index > 0 && <EuiSpacer size="s" />}
                   <Paragraphs
-                    paragraphState={paragraphState}
                     index={index}
                     deletePara={showDeleteParaModal}
                     scrollToPara={scrollToPara}

--- a/public/components/notebooks/components/hypothesis/hypothesis_detail.tsx
+++ b/public/components/notebooks/components/hypothesis/hypothesis_detail.tsx
@@ -240,20 +240,13 @@ export const HypothesisDetail: React.FC = () => {
                       ...currentHypothesis.supportingFindingParagraphIds,
                       ...(currentHypothesis.newAddedFindingIds || []),
                     ]
-                      .map((id) => paragraphsStates.find((p) => p.value.id === id))
-                      .filter(Boolean)
-                      .map((paragraphState, index: number) => {
-                        if (!paragraphState) return null;
-                        return (
-                          <Paragraphs
-                            key={paragraphState.value.id}
-                            paragraphState={paragraphState}
-                            index={index}
-                            deletePara={() => {}}
-                            scrollToPara={() => {}}
-                          />
-                        );
-                      })}
+                      .map((id) => paragraphsStates.findIndex((p) => p.value.id === id))
+                      .filter((index) => index !== -1)
+                      .map((index) => (
+                        <EuiPanel key={paragraphsStates[index].value.id}>
+                          <Paragraphs index={index} deletePara={() => {}} scrollToPara={() => {}} />
+                        </EuiPanel>
+                      ))}
                   </>
                 )}
 

--- a/public/components/notebooks/components/hypothesis/index.ts
+++ b/public/components/notebooks/components/hypothesis/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { HypothesesPanel } from './hypotheses_panel';
+export { HypothesisBadge } from './hypothesis_badge';
+export { HypothesisDetail } from './hypothesis_detail';
+export { HypothesisItem } from './hypothesis_item';
+export { ReinvestigateModal } from './reinvestigate_modal';

--- a/public/components/notebooks/components/hypothesis/reinvestigate_modal.tsx
+++ b/public/components/notebooks/components/hypothesis/reinvestigate_modal.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiOverlayMask,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiFormRow,
+  EuiFieldText,
+  EuiSpacer,
+  EuiSwitch,
+  EuiModalFooter,
+  EuiButton,
+} from '@elastic/eui';
+
+export const ReinvestigateModal: React.FC<{
+  initialGoal: string;
+  confirm: (question: string, isReinvestigate: boolean) => void;
+  closeModal: () => void;
+}> = ({ initialGoal, confirm, closeModal }) => {
+  const [value, setValue] = useState(initialGoal);
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={closeModal}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>
+            <h1>Reinvetigate the issue</h1>
+          </EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+          <EuiFormRow label="Edit inital goal">
+            <EuiFieldText value={value} onChange={(e) => setValue(e.target.value)} required />
+          </EuiFormRow>
+          <EuiSpacer />
+          <EuiSwitch
+            label="Bring the exsiting hypothesis and findings"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+          />
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiButton onClick={() => confirm(value, checked)} fill disabled={!value.trim()}>
+            Confirm
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+};

--- a/public/components/notebooks/components/paragraph_components/markdown/index.tsx
+++ b/public/components/notebooks/components/paragraph_components/markdown/index.tsx
@@ -65,9 +65,6 @@ export const MarkdownParagraph = ({
         },
       ],
     });
-    if (!output?.result) {
-      runParagraphHandler();
-    }
   });
 
   const isRunning = paragraphValue.uiState?.isRunning;

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -10,13 +10,11 @@ import { uiSettingsService } from '../../../../../common/utils';
 import { ParagraphActionPanel } from './paragraph_actions_panel';
 import { NotebookReactContext } from '../../context_provider/context_provider';
 import { getInputType } from '../../../../../common/utils/paragraph';
-import { ParagraphState } from '../../../../../common/state/paragraph_state';
 import { useOpenSearchDashboards } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { NoteBookServices } from '../../../../types';
 import { isAgenticRunBefore } from './utils';
 
 export interface ParagraphProps {
-  paragraphState: ParagraphState<unknown>;
   index: number;
   deletePara: (index: number) => void;
   scrollToPara: (idx: number) => void;

--- a/public/components/notebooks/components/summary_card.tsx
+++ b/public/components/notebooks/components/summary_card.tsx
@@ -25,7 +25,6 @@ import { NotebookReactContext } from '../context_provider/context_provider';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { NoteBookSource } from '../../../../common/types/notebooks';
 import { Filter } from '../../../../../../src/plugins/data/common';
-import { useInvestigation } from '../../../../public/hooks/use_investigation';
 
 interface ContextData {
   variables: {
@@ -41,12 +40,14 @@ interface ContextData {
   initialGoal?: string;
 }
 
-export const SummaryCard = () => {
+export const SummaryCard: React.FC<{
+  isInvestigating: boolean;
+  openReinvestigateModal: () => void;
+}> = ({ isInvestigating, openReinvestigateModal }) => {
   const notebookContext = useContext(NotebookReactContext);
   const {
     services: { uiSettings, notifications },
   } = useOpenSearchDashboards<NoteBookServices>();
-  const { rerunInvestigation, isInvestigating } = useInvestigation();
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text).then(() => {
@@ -78,10 +79,16 @@ export const SummaryCard = () => {
         </EuiTitle>
         <EuiButton
           style={{ marginRight: '20px' }}
-          onClick={() => rerunInvestigation({})}
+          onClick={() => openReinvestigateModal()}
           disabled={isInvestigating}
         >
-          {isInvestigating && <EuiLoadingSpinner />} Reinvestigate
+          {isInvestigating ? (
+            <>
+              <EuiLoadingSpinner /> Investigating
+            </>
+          ) : (
+            'ReInvestigate'
+          )}
         </EuiButton>
       </EuiFlexGroup>
       <EuiSpacer size="s" />

--- a/public/hooks/use_paragraphs.ts
+++ b/public/hooks/use_paragraphs.ts
@@ -216,6 +216,34 @@ export const useParagraphs = (context: { state: NotebookState }) => {
           console.error(err);
         });
     },
+    deleteParagraphsByIds: (paragraphIds: string[]) => {
+      return http
+        .delete(`${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraphs`, {
+          body: JSON.stringify({
+            noteId: id,
+            paragraphIds,
+          }),
+        })
+        .then((_res) => {
+          const newParagraphs = context.state.value.paragraphs.filter(
+            (paragraph) => !paragraphIds.includes(paragraph.value.id)
+          );
+          context.state.updateValue({
+            paragraphs: newParagraphs,
+          });
+          // Clean up context for deleted paragraphs
+          paragraphIds.forEach((paragraphId) => {
+            contextService.deleteParagraphContext(id, paragraphId);
+          });
+          return _res;
+        })
+        .catch((err) => {
+          notifications.toasts.addDanger(
+            'Error deleting paragraphs, please make sure you have the correct permission.'
+          );
+          console.error(err);
+        });
+    },
     // Assigns Loading, Running & inQueue for paragraphs in current notebook
     showParagraphRunning,
     moveParagraph,

--- a/server/adaptors/notebooks/saved_objects_paragraphs_router.tsx
+++ b/server/adaptors/notebooks/saved_objects_paragraphs_router.tsx
@@ -143,6 +143,29 @@ export async function deleteParagraphs(
   }
 }
 
+export async function deleteParagraphsByIds(
+  params: { noteId: string; paragraphIds: string[] },
+  opensearchNotebooksClient: SavedObjectsClientContract
+) {
+  const notebookinfo = await fetchNotebook(params.noteId, opensearchNotebooksClient);
+  const updatedparagraphs = notebookinfo.attributes.savedNotebook.paragraphs.filter(
+    (paragraph) => !params.paragraphIds.includes(paragraph.id)
+  );
+
+  const updateNotebook = {
+    paragraphs: updatedparagraphs,
+    dateModified: new Date().toISOString(),
+  };
+  try {
+    await opensearchNotebooksClient.update(NOTEBOOK_SAVED_OBJECT, params.noteId, {
+      savedNotebook: updateNotebook,
+    });
+    return { paragraphs: updatedparagraphs };
+  } catch (error) {
+    throw new Error('delete Paragraphs Error:' + error);
+  }
+}
+
 export async function updateRunFetchParagraph<TOutput>(
   params: {
     noteId: string;

--- a/server/routes/notebooks/paragraph_router.ts
+++ b/server/routes/notebooks/paragraph_router.ts
@@ -16,6 +16,7 @@ import { NOTEBOOK_SAVED_OBJECT } from '../../../common/types/observability_saved
 import {
   createParagraphs,
   deleteParagraphs,
+  deleteParagraphsByIds,
   updateFetchParagraph,
   updateRunFetchParagraph,
 } from '../../adaptors/notebooks/saved_objects_paragraphs_router';
@@ -163,6 +164,37 @@ export function registerParaRoute(router: IRouter) {
         );
         return response.ok({
           body: saveResponse,
+        });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+  router.delete(
+    {
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraphs`,
+      validate: {
+        body: schema.object({
+          noteId: schema.string(),
+          paragraphIds: schema.arrayOf(schema.string()),
+        }),
+      },
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        const deleteResponse = await deleteParagraphsByIds(
+          request.body,
+          context.core.savedObjects.client
+        );
+        return response.ok({
+          body: deleteResponse,
         });
       } catch (error) {
         return response.custom({


### PR DESCRIPTION
### Description
Rerun with existing hypotheses and findings, which are present and add to the prompt during reinvestigate (using `reinvestigate` logic):

https://github.com/user-attachments/assets/8cfa3c50-a423-4ac4-b7fb-545c4f72cbb6

Rerun without existing hypotheses and findings, they will be deleted beforehand (using `doInvestigation` logic) to generate a brand new hypothesis:

https://github.com/user-attachments/assets/34380aea-b30c-406f-8752-5079fef5f180

The initial investigation question (`initalGoal`) can be changed and will be updated in both scenarios. 

Also, added a delete API for list a list of paragraph.

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
