### PR TITLE
[Bug]Permission error toast shown when deleting a notebook

### DIFF
--- a/public/components/notebooks/components/notebook_header.tsx
+++ b/public/components/notebooks/components/notebook_header.tsx
@@ -230,7 +230,7 @@ export const NotebookHeader = ({
           await deleteSingleNotebook(openedNoteId, toastMessage);
           setIsModalVisible(false);
           setTimeout(() => {
-            history.push('.');
+            history.push(notebookType === NotebookType.AGENTIC ? '..' : '.');
           }, 1000);
         }}
         onCancel={() => setIsModalVisible(false)}
@@ -239,7 +239,7 @@ export const NotebookHeader = ({
       />
     );
     setIsModalVisible(true);
-  }, [path, deleteSingleNotebook, openedNoteId, history]);
+  }, [path, deleteSingleNotebook, openedNoteId, notebookType, history]);
 
   const reportingActionPanels: EuiContextMenuPanelDescriptor[] = useMemo(
     () => [


### PR DESCRIPTION
### Description

This PR fixes a bug that caused permission error toast to appear when deleting agentic notebook


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
