### PR TITLE
Add validation in ml proxy to only allow some APIs

### DIFF
--- a/public/utils/ml_commons_apis.ts
+++ b/public/utils/ml_commons_apis.ts
@@ -238,15 +238,14 @@ export const getMLCommonsAgentDetail = ({
   signal?: AbortSignal;
   agentId: string;
   dataSourceId?: string;
-}) => {
-  return http.get({
-    path: `${NOTEBOOKS_API_PREFIX}/agents/${agentId}`,
-    query: {
-      dataSourceId,
-    },
+}) =>
+  callApiWithProxy({
+    http,
+    method: 'GET',
+    path: OPENSEARCH_ML_COMMONS_API.agentDetail.replace('{agentId}', agentId),
     signal,
+    dataSourceId,
   });
-};
 
 // Get single message response after agent execution. by Parent Interaction ID
 export const executeMLCommonsAgenticMessage = ({

--- a/server/routes/notebooks/__tests__/ml_router.test.ts
+++ b/server/routes/notebooks/__tests__/ml_router.test.ts
@@ -44,33 +44,14 @@ describe('ML Router - API Path Validation', () => {
       },
     });
 
-    it('should allow memory container API paths', async () => {
+    it('should allow allowed API paths', async () => {
       const allowedPaths = [
         '/_plugins/_ml/memory_containers/container-id/memories/working/_search',
         '/_plugins/_ml/memory_containers/test-container/memories/sessions',
+        '/_plugins/_ml/config/config_name',
+        '/_plugins/_ml/agents/agent_id',
+        '/_plugins/_ml/insights/index_name/LOG_RELATED_INDEX_CHECK',
       ];
-
-      for (const path of allowedPaths) {
-        const request = createMockRequest(path);
-        const response = httpServerMock.createResponseFactory();
-        const context = createMockContext();
-
-        jest.spyOn(utils, 'getOpenSearchClientTransport').mockResolvedValue({
-          request: jest.fn().mockResolvedValue({
-            body: { result: 'success' },
-            statusCode: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }),
-        });
-
-        await routeHandler(context, request, response);
-
-        expect(response.forbidden).not.toHaveBeenCalled();
-      }
-    });
-
-    it('should allow ML config API paths', async () => {
-      const allowedPaths = ['/_plugins/_ml/config/agent_framework_enabled'];
 
       for (const path of allowedPaths) {
         const request = createMockRequest(path);
@@ -101,6 +82,9 @@ describe('ML Router - API Path Validation', () => {
         '/_plugins/_ml/memory_containers//memories/sessions',
         '/_plugins/_ml/memory_containers/memories/working/_search',
         '/_plugins/_ml/memory_containers/memories/sessions',
+        '/_plugins/_ml/config/agent_framework_enabled/test',
+        '/_plugins/_ml/agents/id/test',
+        '/_plugins/_ml/insights/id/LOG_RELATED_INDEX_CHECK/test',
       ];
 
       for (const path of nonMLPaths) {

--- a/server/routes/notebooks/agent_router.ts
+++ b/server/routes/notebooks/agent_router.ts
@@ -338,44 +338,4 @@ Remember: Respond only in JSON format following the required schema.`;
       }
     }
   );
-
-  // Get agent details
-  router.get(
-    {
-      path: `${NOTEBOOKS_API_PREFIX}/agents/{agentId}`,
-      validate: {
-        params: schema.object({
-          agentId: schema.string(),
-        }),
-        query: schema.object({
-          dataSourceId: schema.maybe(schema.string()),
-        }),
-      },
-    },
-    async (context, request, response): Promise<IOpenSearchDashboardsResponse> => {
-      try {
-        const { agentId } = request.params;
-        const { dataSourceId } = request.query;
-        const transport = await getOpenSearchClientTransport({
-          context,
-          request,
-          dataSourceId,
-        });
-
-        const result = await transport.request({
-          path: `/_plugins/_ml/agents/${agentId}`,
-          method: 'GET',
-        });
-
-        return response.ok({
-          body: result.body,
-        });
-      } catch (error) {
-        return response.custom({
-          statusCode: error.statusCode || 500,
-          body: error,
-        });
-      }
-    }
-  );
 }

--- a/server/routes/notebooks/ml_router.ts
+++ b/server/routes/notebooks/ml_router.ts
@@ -64,6 +64,10 @@ function isAllowedMLPath(path: string): boolean {
     /^\/_plugins\/_ml\/memory_containers\/[^/]+\/memories\/sessions$/,
     // ML Config API
     /^\/_plugins\/_ml\/config\/[^/]+$/,
+    // Index Insight API
+    /^\/_plugins\/_ml\/insights\/[^/]+\/LOG_RELATED_INDEX_CHECK$/,
+    // Agent Detail API
+    /^\/_plugins\/_ml\/agents\/[^/]+$/,
   ];
 
   // Check if path matches any allowed pattern


### PR DESCRIPTION
### Description
Add validation in ml proxy to only allow some APIs
 - /_plugins/_ml/config/{configName}
 - /_plugins/_ml/memory_containers/{memory_container_id}/memories/sessions
 - /_plugins/_ml/memory_containers/{memory_container_id}/memories/working/_search
 - /_plugins/_ml/insights/${index}/LOG_RELATED_INDEX_CHECK
 - /_plugins/_ml/agents/${agent_id}

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
