### PR TITLE
[Bug] fix two login window error

### DIFF
--- a/server/services/base_service.ts
+++ b/server/services/base_service.ts
@@ -36,7 +36,10 @@ export class BaseService {
     }
     const savedObjectsClient = this.coreStart.savedObjects.getScopedClient(request);
     const uiSettingsClient = this.coreStart.uiSettings.asScopedToClient(savedObjectsClient);
-    const isAgenticFeatureEnabledBySetting = await uiSettingsClient.get(ENABLE_AI_FEATURES);
+
+    const isAgenticFeatureEnabledBySetting = Boolean(
+      await uiSettingsClient.get(ENABLE_AI_FEATURES).catch(() => false)
+    );
 
     try {
       const dynamicConfig = await client.getConfig(


### PR DESCRIPTION
### Description
When accessing the OpenSearch Dashboards login page, the browser displays an HTTP Basic Authentication dialog, which is not the expected behavior.
<img width="1383" height="854" alt="image" src="https://github.com/user-attachments/assets/8c73188d-c0d1-45ba-a1c2-c7dc044753af" />

#### Root Cause:

When the login page loads, the frontend makes a `/api/core/capabilities` which permits access from unauthenticated users. However, the capabilities switcher registered by the dashboards-investigation plugin calls `uiSettingsClient` when processing this request. For unauthenticated requests, these operations trigger access to OpenSearch, which returns a 401 Unauthorized response with the header `WWW-Authenticate: Basic realm="OpenSearch Security"`. When the browser detects this header, it automatically displays the HTTP Basic Authentication dialog.

### Issues Resolved
Add .catch(() => false) to handle errors from unauthenticated requests with degradation.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
