### PR TITLE
Add investigation page context for agentic notebook

### DIFF
--- a/public/components/notebooks/components/__tests__/investigation_page_context.test.tsx
+++ b/public/components/notebooks/components/__tests__/investigation_page_context.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { InvestigationPageContext } from '../investigation_page_context';
+import { investigationNotebookID } from '../../../../../common/constants/shared';
+
+describe('<InvestigationPageContext /> spec', () => {
+  const mockUsePageContext = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls usePageContext with correct parameters without dataSourceId', () => {
+    render(<InvestigationPageContext usePageContext={mockUsePageContext} />);
+
+    expect(mockUsePageContext).toHaveBeenCalledTimes(1);
+    expect(mockUsePageContext).toHaveBeenCalledWith({
+      description: 'Investigation notebooks application page context',
+      convert: expect.any(Function),
+    });
+
+    // Test the convert function returns correct structure without dataSourceId
+    const convertFn = mockUsePageContext.mock.calls[0][0].convert;
+    const result = convertFn();
+
+    expect(result).toEqual({
+      appId: investigationNotebookID,
+      dataset: {
+        dataSource: { id: undefined },
+      },
+    });
+  });
+
+  it('calls usePageContext with correct parameters with dataSourceId', () => {
+    const testDataSourceId = 'test-datasource-123';
+
+    render(
+      <InvestigationPageContext
+        usePageContext={mockUsePageContext}
+        dataSourceId={testDataSourceId}
+      />
+    );
+
+    expect(mockUsePageContext).toHaveBeenCalledTimes(1);
+    expect(mockUsePageContext).toHaveBeenCalledWith({
+      description: 'Investigation notebooks application page context',
+      convert: expect.any(Function),
+    });
+
+    // Test the convert function returns correct structure with dataSourceId
+    const convertFn = mockUsePageContext.mock.calls[0][0].convert;
+    const result = convertFn();
+
+    expect(result).toEqual({
+      appId: investigationNotebookID,
+      dataset: {
+        dataSource: { id: testDataSourceId },
+      },
+    });
+  });
+});

--- a/public/components/notebooks/components/agentic_notebook.tsx
+++ b/public/components/notebooks/components/agentic_notebook.tsx
@@ -51,6 +51,7 @@ import { useChatContextProvider } from '../../../hooks/use_chat_context';
 import { HypothesisDetail, HypothesesPanel, ReinvestigateModal } from './hypothesis';
 import { SubRouter, useSubRouter } from '../../../hooks/use_sub_router';
 import { formatTimeRangeString } from '../../../../public/utils/time';
+import { InvestigationPageContext } from './investigation_page_context';
 
 interface AgenticNotebookProps extends NotebookComponentProps {
   openedNoteId: string;
@@ -58,7 +59,7 @@ interface AgenticNotebookProps extends NotebookComponentProps {
 
 function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
   const {
-    services: { notifications, findingService, chrome, chat, uiSettings },
+    services: { notifications, findingService, chrome, chat, uiSettings, contextProvider },
   } = useOpenSearchDashboards<NoteBookServices>();
 
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -72,7 +73,7 @@ function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
   useChatContextProvider();
 
   const notebookContext = useContext(NotebookReactContext);
-  const { initialGoal, source, notebookType, timeRange } = useObservable(
+  const { initialGoal, source, notebookType, timeRange, dataSourceId } = useObservable(
     notebookContext.state.value.context.getValue$(),
     notebookContext.state.value.context.value
   );
@@ -399,6 +400,12 @@ function NotebookComponent({ showPageHeader }: NotebookComponentProps) {
           dateFormat={uiSettings.get('dateFormat')}
           confirm={handleReinvestigate}
           closeModal={() => setIsReinvestigateModalVisible(false)}
+        />
+      )}
+      {contextProvider?.hooks?.usePageContext && (
+        <InvestigationPageContext
+          usePageContext={contextProvider.hooks.usePageContext}
+          dataSourceId={dataSourceId}
         />
       )}
     </>

--- a/public/components/notebooks/components/investigation_page_context.tsx
+++ b/public/components/notebooks/components/investigation_page_context.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { investigationNotebookID } from '../../../../common/constants/shared';
+import type { NoteBookServices } from '../../../types';
+
+export interface InvestigationPageContextProps {
+  usePageContext: Required<NoteBookServices>['contextProvider']['hooks']['usePageContext'];
+  dataSourceId?: string;
+}
+
+export const InvestigationPageContext = ({
+  usePageContext,
+  dataSourceId,
+}: InvestigationPageContextProps) => {
+  usePageContext({
+    description: 'Investigation notebooks application page context',
+    convert: () => ({
+      appId: investigationNotebookID,
+      dataset: {
+        dataSource: { id: dataSourceId },
+      },
+    }),
+  });
+  return null;
+};


### PR DESCRIPTION
### Description

Add page context for agentic notebook, the context will be present on the chat proxy request like screenshot below:
<img width="1093" height="203" alt="image" src="https://github.com/user-attachments/assets/3a291362-12cc-47a1-b1a2-be577d6cf192" />

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
