### PR TITLE
feat: add include_details false for index patterns or wildcard

### DIFF
--- a/server/routes/notebooks/agent_router.ts
+++ b/server/routes/notebooks/agent_router.ts
@@ -21,6 +21,8 @@ const commonInstructions = `
 - Avoid vague instructions; be specific about data sources, indexes, or parameters
 - Never make assumptions or rely on implicit knowledge
 - Respond only in JSON format
+${/* Avoid too many tokens when it is an index pattern */ ''}
+- When using ListIndexTool, use include_details false when the input is an index pattern or wildcard.
 
 ## Step Examples
 **Good example:** "Use Tool to sample documents from index: 'my-index'"


### PR DESCRIPTION
### Description

ListIndexTool in opensearch-mcp-server has a feature to get index details: https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/src/tools/tools.py#L69 . But if the index name is a wildcard, the tool may return MBs of tokens. This PR address the issue by telling LLM to set `include_details: false` when the parameters is a wildcard.

#### Before the PR
<img width="936" height="618" alt="image" src="https://github.com/user-attachments/assets/acb22fe2-ab8e-4ed0-a04f-96e384e555c3" />


#### After the PR
<img width="955" height="502" alt="image" src="https://github.com/user-attachments/assets/4c9dd4c1-3711-466d-b6bb-5b1caf4d7a11" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
