### PR TITLE
feat: hide stack trace when showing full error

### DIFF
--- a/public/hooks/use_investigation.ts
+++ b/public/hooks/use_investigation.ts
@@ -259,10 +259,17 @@ ${finding.evidence}
               const errorMessage = error.message;
               context.state.updateValue({ investigationError: errorMessage });
               await updateHypotheses(hypothesesRef.current || []);
-              notifications.toasts.addError(error, {
-                title: errorTitle,
-                toastMessage: errorMessage,
-              });
+              notifications.toasts.addError(
+                {
+                  ...error,
+                  stack: '',
+                  message: errorMessage,
+                },
+                {
+                  title: errorTitle,
+                  toastMessage: errorMessage,
+                }
+              );
               reject(error);
             } finally {
               context.state.updateValue({ runningMemory: undefined });
@@ -573,7 +580,7 @@ ${convertParagraphsToFindings(newAddedFindingParagraphs)}`
     } catch (error) {
       const errorMessage = 'Failed to continue investigation';
       context.state.updateValue({ runningMemory: undefined, investigationError: errorMessage });
-      notifications.toasts.addError(error, { title: errorMessage });
+      notifications.toasts.addError(error.body || error, { title: errorMessage });
       setIsInvestigating(false);
     }
   }, [context.state, notifications, pollInvestigationCompletion]);


### PR DESCRIPTION
### Description

Hide stack since it is useless for trouble shooting and may confuse users.

#### Before
<img width="1646" height="1126" alt="image" src="https://github.com/user-attachments/assets/b8615628-f751-4465-b11d-c8017b399eb1" />

#### After
<img width="1648" height="498" alt="image" src="https://github.com/user-attachments/assets/2fa6e45b-2a59-4126-a8f3-90c864e19e04" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
