### PR TITLE
Reduce initial goal textarea to 3 rows

### DIFF
--- a/public/components/notebooks/components/discover_explorer/start_investigation_modal.tsx
+++ b/public/components/notebooks/components/discover_explorer/start_investigation_modal.tsx
@@ -179,6 +179,7 @@ export const StartInvestigationModal = ({ log, closeModal }: StartInvestigationM
             onKeyUp={handleInputKeyUp}
             disabled={disabled}
             fullWidth
+            rows={3}
           />
         </EuiFormRow>
         <EuiSpacer size="s" />


### PR DESCRIPTION
### Description
Reduce initial goal textarea to 3 rows to avoid suggested actions hidden by default on small screens

Before:
<img width="1067" height="721" alt="image" src="https://github.com/user-attachments/assets/b7241e0b-b198-4424-a5d7-35ae529cc65e" />

After:
<img width="1059" height="723" alt="image" src="https://github.com/user-attachments/assets/f9deac9e-2d43-4ffe-b1b8-bd264f0fabc4" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
