### PR TITLE
Fix empty field comparison case and percentage calculation in data distribution context prompt

### DIFF
--- a/public/paragraphs/data_distribution.ts
+++ b/public/paragraphs/data_distribution.ts
@@ -20,6 +20,10 @@ export const DataDistributionParagraphItem: ParagraphRegistryItem<AnomalyVisuali
     const allFieldComparison = paragraph?.output?.[0]?.result?.fieldComparison || [];
     const selectedFieldComparison = allFieldComparison.filter((item) => !item.excludeFromContext);
 
+    if (selectedFieldComparison.length === 0) {
+      return '';
+    }
+
     const hasBaseline = selectedFieldComparison.some((f) =>
       f.topChanges.some((c) => c.baselinePercentage !== undefined)
     );
@@ -57,8 +61,6 @@ export const DataDistributionParagraphItem: ParagraphRegistryItem<AnomalyVisuali
 4. Cross-reference field values with log patterns to identify root causes`;
 
     const formatFieldData = () => {
-      if (selectedFieldComparison.length === 0) return 'No field data available.';
-
       return selectedFieldComparison
         .map((field, i) => {
           const changes = field.topChanges


### PR DESCRIPTION
### Description
Don't include any data distribution instruction context prompt when there is no field comparison at all.

Also fix the percentage calculation, after fix:
```
[10] Field: body
  Top Values:
  - "could not charge the card: rpc error: code = Unknown desc = Payment request failed. Invalid token. app.loyalty.level=gold": 42.0%
  - "failed to charge card: could not charge the card: rpc error: code = Unknown desc = Payment request failed. Invalid token. app.loyalty.level=gold": 42.0%
  - "failed to get product #"OLJCESPC7Z"": 7.0%
  - "failed to prepare order: failed to get product #"OLJCESPC7Z"": 7.0%
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
