### PR TITLE
fix: add nvm install step

### DIFF
--- a/.github/workflows/dashboards-investigation-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-investigation-test-and-build-workflow.yml
@@ -46,7 +46,7 @@ jobs:
           command: |
             chown -R 1000:1000 `pwd`
             cd ./OpenSearch-Dashboards/
-            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && node -v && yarn -v &&
+            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && npm i -g yarn && node -v && yarn -v &&
                                  yarn config set network-timeout 1000000 -g &&
                                  yarn osd bootstrap --single-version=loose"
 
@@ -54,7 +54,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && npm i -g yarn && node -v && yarn -v &&
                                cd plugins/dashboards-investigation &&
                                yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
 


### PR DESCRIPTION
### Description

The node version gets bumped to 22.22.0 and the container does have 22.22.0 installed by default. This PR manually installs the 22.22.0.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
