### PR TITLE
Fix reinvestigate button should with readonly user

### DIFF
--- a/public/components/notebooks/components/investigation_result.tsx
+++ b/public/components/notebooks/components/investigation_result.tsx
@@ -301,16 +301,18 @@ export const InvestigationResult: React.FC<InvestigationResultProps> = ({
   const renderRetryButtonGroup = (justifyContent: 'center' | 'flexStart' = 'center') => {
     return (
       <EuiFlexGroup gutterSize="none" justifyContent={justifyContent} style={{ gap: 8 }}>
-        <EuiSmallButton
-          color="primary"
-          iconType="refresh"
-          fill
-          onClick={() => openReinvestigateModal(true)}
-        >
-          {i18n.translate('notebook.summary.card.reinvestigateWithFeedback', {
-            defaultMessage: 'Reinvestigate with feedback',
-          })}
-        </EuiSmallButton>
+        {!isNotebookReadonly && (
+          <EuiSmallButton
+            color="primary"
+            iconType="refresh"
+            fill
+            onClick={() => openReinvestigateModal(true)}
+          >
+            {i18n.translate('notebook.summary.card.reinvestigateWithFeedback', {
+              defaultMessage: 'Reinvestigate with feedback',
+            })}
+          </EuiSmallButton>
+        )}
         {!!failedInvestigation && failedInvestigationDetailButton}
         {/* <EuiButton
           color="text"

--- a/public/hooks/use_memory_permission.test.tsx
+++ b/public/hooks/use_memory_permission.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { waitFor } from '@testing-library/react';
 import { useMemoryPermission } from './use_memory_permission';
 import { getMemoryPermission } from '../components/notebooks/components/hypothesis/investigation/utils';
@@ -111,7 +111,7 @@ describe('useMemoryPermission', () => {
     it('should call getMemoryPermission and return the result', async () => {
       mockGetMemoryPermission.mockResolvedValue(true);
 
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () =>
           useMemoryPermission({
             memoryContainerId: 'memory-123',
@@ -125,9 +125,9 @@ describe('useMemoryPermission', () => {
       // Initially false (before async check completes)
       expect(result.current).toBe(false);
 
-      await waitForNextUpdate();
-
-      expect(result.current).toBe(true);
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
 
       expect(mockGetMemoryPermission).toHaveBeenCalledWith({
         http: mockHttp,


### PR DESCRIPTION
### Description
<img width="1443" height="714" alt="Screenshot 2026-02-03 at 10 01 37" src="https://github.com/user-attachments/assets/5a86fcb3-048f-49d8-904c-f314c4e9ba71" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
