### PR TITLE
fix: use html2canvas pro to fix csp violation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ajv": "^8.11.0",
     "autosize": "^6.0.1",
     "dompurify": "^3.2.4",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^1.6.6",
     "json5": "^2.2.3",
     "lru-cache": "^4.1.5",
     "mime": "^3.0.0",

--- a/public/paragraphs/visualization.ts
+++ b/public/paragraphs/visualization.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import html2canvas from 'html2canvas';
+import html2canvas from 'html2canvas-pro';
 import { VisualizationParagraph } from '../components/notebooks/components/paragraph_components/visualization';
 import { ParagraphRegistryItem } from '../services/paragraph_service';
 import { getClient } from '../services';
@@ -110,6 +110,10 @@ export const VisualizationParagraphItem: ParagraphRegistryItem = {
       const visualizationContainer = await waitForVisualizationRendered(id);
 
       // Use html2canvas to capture the visualization as an image
+      const nonce = document.querySelector('meta[name="csp-nonce"]')?.getAttribute('content');
+      if (nonce) {
+        html2canvas.setCspNonce(nonce);
+      }
       const canvas = await html2canvas(visualizationContainer as HTMLElement, {
         backgroundColor: '#ffffff',
         scale: 1, // Lower scale for smaller file size

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,10 +929,10 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-html2canvas@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
-  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+html2canvas-pro@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/html2canvas-pro/-/html2canvas-pro-1.6.6.tgz#affd603d2d59042b84cd45c9351b805946d4280c"
+  integrity sha512-5mRhTXZhv4B0kIcsn3bFBjol2o8vzP35mhtxdXBGPA3V3gZd6Sa2PIIFbT//DiqAX8UuywlcJit5jRKej4nV4Q==
   dependencies:
     css-line-break "^2.1.0"
     text-segmentation "^1.0.3"


### PR DESCRIPTION
### Description
Use html2canvas-pro with csp nonce to fix csp violation.

### Issues Resolved
#312 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
