### PR TITLE
fix: resolve stale closure preventing investigation title update

### DIFF
--- a/public/hooks/use_investigation.test.tsx
+++ b/public/hooks/use_investigation.test.tsx
@@ -1028,6 +1028,319 @@ describe('useInvestigation', () => {
     });
   });
 
+  describe('updateInvestigationName', () => {
+    let mockSharedMessagePollingService: any;
+
+    beforeEach(() => {
+      mockSharedMessagePollingService = {
+        poll: jest.fn(),
+      };
+
+      (SharedMessagePollingService.getInstance as jest.Mock) = jest
+        .fn()
+        .mockReturnValue(mockSharedMessagePollingService);
+
+      (mlCommonsApis.getMLCommonsConfig as jest.Mock).mockResolvedValue({
+        configuration: { agent_id: 'test-agent-id' },
+      });
+      (mlCommonsApis.getMLCommonsAgentDetail as jest.Mock).mockResolvedValue({
+        memory: { memory_container_id: 'test-container-id' },
+      });
+      (mlCommonsApis.createAgenticExecutionMemory as jest.Mock).mockResolvedValue({
+        session_id: 'test-session-id',
+      });
+      (mlCommonsApis.executeMLCommonsAgent as jest.Mock).mockResolvedValue({
+        response: {
+          parent_interaction_id: 'test-parent-interaction',
+        },
+      });
+      ((isValidPERAgentInvestigationResponse as unknown) as jest.Mock).mockReturnValue(true);
+
+      mockParagraphHooks.batchDeleteParagraphs.mockResolvedValue({});
+      mockParagraphHooks.batchCreateParagraphs.mockResolvedValue({ paragraphs: [] });
+      mockParagraphHooks.batchRunParagraphs.mockResolvedValue({});
+    });
+
+    it('should rename notebook when title is default investigation name', async () => {
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: 'Discover investigation',
+        path: 'Discover investigation',
+      });
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: 'Web Log Anomaly Analysis',
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      expect(mockHttp.put).toHaveBeenCalledWith(
+        expect.stringContaining('/note/savedNotebook/rename'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'Web Log Anomaly Analysis',
+            noteId: state.value.id,
+          }),
+        })
+      );
+      expect(state.value.title).toBe('Web Log Anomaly Analysis');
+      expect(state.value.path).toBe('Web Log Anomaly Analysis');
+    });
+
+    it('should rename notebook when title is default visualization name', async () => {
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: 'Visualization investigation',
+        path: 'Visualization investigation',
+      });
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: 'Dashboard Analysis',
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      expect(mockHttp.put).toHaveBeenCalledWith(
+        expect.stringContaining('/note/savedNotebook/rename'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'Dashboard Analysis',
+            noteId: state.value.id,
+          }),
+        })
+      );
+    });
+
+    it('should not rename notebook when title is already custom', async () => {
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: 'My Custom Investigation',
+        path: 'My Custom Investigation',
+      });
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: 'Web Log Anomaly Analysis',
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      expect(mockHttp.put).not.toHaveBeenCalledWith(
+        expect.stringContaining('/note/savedNotebook/rename'),
+        expect.anything()
+      );
+      expect(state.value.title).toBe('My Custom Investigation');
+    });
+
+    it('should truncate investigation name to 50 characters', async () => {
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: 'Discover investigation',
+        path: 'Discover investigation',
+      });
+
+      const longName = 'A'.repeat(60);
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: longName,
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      expect(mockHttp.put).toHaveBeenCalledWith(
+        expect.stringContaining('/note/savedNotebook/rename'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: longName.substring(0, 50),
+            noteId: state.value.id,
+          }),
+        })
+      );
+    });
+
+    it('should read title from state.value at call time to avoid stale closure', async () => {
+      // Start with empty title (simulating initial state before notebook loads)
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: '',
+        path: '',
+      });
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: 'Web Log Anomaly Analysis',
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      // Simulate title being updated after notebook loads (before polling completes)
+      // This mimics the real scenario where state.value.title is updated by loadNotebook
+      // but the useCallback closure would have captured the old empty title
+      state.updateValue({ title: 'Discover investigation', path: 'Discover investigation' });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      // Should still rename because we read from state.value.title (current)
+      // not from the stale closure value
+      expect(mockHttp.put).toHaveBeenCalledWith(
+        expect.stringContaining('/note/savedNotebook/rename'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'Web Log Anomaly Analysis',
+            noteId: state.value.id,
+          }),
+        })
+      );
+    });
+
+    it('should not fail the investigation if rename API call fails', async () => {
+      const state = new NotebookState({
+        ...mockNotebookState.value,
+        title: 'Discover investigation',
+        path: 'Discover investigation',
+      });
+
+      mockHttp.put.mockRejectedValueOnce(new Error('Rename API failed'));
+
+      mockSharedMessagePollingService.poll.mockReturnValue(
+        of({
+          message: JSON.stringify({
+            investigationName: 'Web Log Anomaly Analysis',
+            findings: [],
+            hypotheses: [],
+            topologies: [],
+          }),
+          createTime: 1711267562195,
+          updateTime: 1711267592195,
+        })
+      );
+
+      const { result } = renderHook(() => useInvestigation(), {
+        wrapper: ({ children }) => (
+          <NotebookReactContext.Provider value={{ state, paragraphHooks: mockParagraphHooks }}>
+            {children}
+          </NotebookReactContext.Provider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.doInvestigate({
+          investigationQuestion: 'Test question',
+        });
+      });
+
+      // Should show error toast for rename failure but not fail the investigation
+      expect(mockAddError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to update investigation title',
+        })
+      );
+      // Investigation itself should still complete successfully
+      expect(state.value.investigationPhase).toBe(InvestigationPhase.COMPLETED);
+    });
+  });
+
   describe('recoverable failure handling', () => {
     let mockSharedMessagePollingService: any;
 

--- a/public/hooks/use_investigation.ts
+++ b/public/hooks/use_investigation.ts
@@ -273,8 +273,10 @@ export const useInvestigation = () => {
    */
   const updateInvestigationName = useCallback(
     async (suggestedName: string) => {
+      // Read title directly from the state value to avoid stale closure issues
+      const currentTitle = context.state.value.title || '';
       const isDefaultName = [DEFAULT_INVESTIGATION_NAME, DEFAULT_VISUALIZATION_NAME].includes(
-        contextStateValue?.title || ''
+        currentTitle
       );
       if (isDefaultName && suggestedName) {
         try {
@@ -298,7 +300,7 @@ export const useInvestigation = () => {
         }
       }
     },
-    [contextStateValue?.title, context.state, http, addError]
+    [context.state, http, addError]
   );
 
   const handleInvestigationFailure = useCallback(


### PR DESCRIPTION
### Description
Read title from context.state.value instead of contextStateValue to avoid stale React render snapshot in the useCallback closure chain.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
