### PR TITLE
Improve investigation creation UX and response message

### DIFF
--- a/public/chat/actions/components/ConfirmInvestigationStep.tsx
+++ b/public/chat/actions/components/ConfirmInvestigationStep.tsx
@@ -44,7 +44,7 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
     if (typeof data === 'string') {
       try {
         return JSON.parse(data);
-      } catch (e) {
+      } catch (_e) {
         // If JSON is incomplete/invalid, return empty object
         return {};
       }
@@ -71,7 +71,7 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
       if (fromMoment && toMoment && fromMoment.isValid() && toMoment.isValid()) {
         return `${fromMoment.format(dateFormat)} to ${toMoment.format(dateFormat)}`;
       }
-    } catch (e) {
+    } catch (_e) {
       // Fallback to raw values if parsing fails
       return `${timeRange.from} to ${timeRange.to}`;
     }

--- a/public/chat/actions/components/ConfirmInvestigationStep.tsx
+++ b/public/chat/actions/components/ConfirmInvestigationStep.tsx
@@ -35,6 +35,7 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
   onCancel,
   onConfirm,
 }) => {
+  const [isActionTaken, setIsActionTaken] = React.useState(false);
   const { uiSettings } = services;
   const dateFormat = uiSettings?.get('dateFormat');
 
@@ -92,7 +93,9 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
               )}
               <EuiFlexItem>
                 <EuiText size="s">
-                  <strong>Confirm investigation details</strong>
+                  <strong>
+                    {isStreaming ? 'Preparing investigation...' : 'Confirm investigation details'}
+                  </strong>
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -144,7 +147,7 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
             </EuiFlexGroup>
           </EuiSplitPanel.Inner>
 
-          {!isComplete && (
+          {!isComplete && !isStreaming && (
             <EuiSplitPanel.Inner color="subdued" paddingSize="s">
               <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
                 <EuiFlexItem>
@@ -159,8 +162,12 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
                         <EuiButtonIcon
                           iconType="pencil"
                           aria-label="Edit investigation details"
-                          onClick={onEdit}
+                          onClick={() => {
+                            setIsActionTaken(true);
+                            onEdit!();
+                          }}
                           color="text"
+                          isDisabled={isActionTaken}
                         />
                       </EuiFlexItem>
                     )}
@@ -169,8 +176,12 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
                         <EuiButtonIcon
                           iconType="crossInCircleEmpty"
                           aria-label="Cancel investigation"
-                          onClick={onCancel}
+                          onClick={() => {
+                            setIsActionTaken(true);
+                            onCancel!();
+                          }}
                           color="danger"
+                          isDisabled={isActionTaken}
                         />
                       </EuiFlexItem>
                     )}
@@ -179,8 +190,12 @@ export const ConfirmInvestigationStep: React.FC<Props> = ({
                         <EuiButtonIcon
                           iconType="checkInCircleEmpty"
                           aria-label="Confirm investigation"
-                          onClick={onConfirm}
+                          onClick={() => {
+                            setIsActionTaken(true);
+                            onConfirm!();
+                          }}
                           color="success"
+                          isDisabled={isActionTaken}
                         />
                       </EuiFlexItem>
                     )}

--- a/public/chat/actions/components/CreateInvestigationToolResult.tsx
+++ b/public/chat/actions/components/CreateInvestigationToolResult.tsx
@@ -12,7 +12,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import React, { useState } from 'react';
+import React from 'react';
 import { CoreStart } from '../../../../../../src/core/public';
 import { ConfirmInvestigationStep } from './ConfirmInvestigationStep';
 import { ToolStatus } from '../../../../../../src/plugins/context_provider/public';
@@ -40,8 +40,6 @@ export const CreateInvestigationToolResult: React.FC<Props> = ({
   onApprove,
   onReject,
 }) => {
-  const [isAccordionOpen, setIsAccordionOpen] = useState(false);
-
   // Return null if we have neither args nor result
   if (!args && !result) {
     return null;
@@ -81,7 +79,6 @@ export const CreateInvestigationToolResult: React.FC<Props> = ({
           }
           arrowDisplay="right"
           paddingSize="none"
-          onToggle={(isOpen) => setIsAccordionOpen(isOpen)}
         >
           <EuiSpacer size="s" />
           <ConfirmInvestigationStep data={args!} services={services} isComplete={true} />
@@ -89,13 +86,8 @@ export const CreateInvestigationToolResult: React.FC<Props> = ({
           <CreatingInvestigationStep services={services} isComplete={true} />
         </EuiAccordion>
 
-        {/* Investigation Link Panel - Only show when accordion is collapsed */}
-        {!isAccordionOpen && (
-          <>
-            <EuiSpacer size="xs" />
-            <InvestigationLinkPanel result={result} services={services} />
-          </>
-        )}
+        <EuiSpacer size="xs" />
+        <InvestigationLinkPanel result={result} services={services} />
       </EuiPanel>
     );
   }

--- a/public/chat/actions/components/__tests__/ConfirmInvestigationStep.test.tsx
+++ b/public/chat/actions/components/__tests__/ConfirmInvestigationStep.test.tsx
@@ -43,7 +43,7 @@ describe('ConfirmInvestigationStep', () => {
 
     render(<ConfirmInvestigationStep {...defaultProps} data={incompleteData} />);
 
-    expect(screen.getAllByText('Confirm investigation details').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Preparing investigation...')).toBeInTheDocument();
     // EuiLoadingSpinner should show when data is incomplete
     expect(document.querySelector('.euiLoadingSpinner')).toBeInTheDocument();
   });
@@ -63,7 +63,7 @@ describe('ConfirmInvestigationStep', () => {
 
     render(<ConfirmInvestigationStep {...defaultProps} data={partialJsonString as any} />);
 
-    expect(screen.getAllByText('Confirm investigation details').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Preparing investigation...')).toBeInTheDocument();
     // Should show spinner for incomplete JSON
     expect(document.querySelector('.euiLoadingSpinner')).toBeInTheDocument();
     // Should show placeholders for missing fields

--- a/public/chat/actions/create_investigation_action.tsx
+++ b/public/chat/actions/create_investigation_action.tsx
@@ -258,7 +258,7 @@ export const createInvestigationAction = (
           index: args.index,
           timeRange: args.timeRange,
           message: `Investigation created successfully. Reply ONLY with this exact format, do NOT add any extra description or elaboration:
-          '✅ Investigation **<Name>** created.\n\n**Goal:** <repeat the user's original goal exactly as they stated it, nothing more>\n\n👉 Click the above link to open and start running it.'`,
+          '✅ Investigation **<Name>** created.\n\n**Goal:** <repeat the user's original goal exactly as they stated it, nothing more>\n\n👉 Click the link above to open and run the investigation.'`,
         };
       } catch (error) {
         return {

--- a/public/chat/actions/create_investigation_action.tsx
+++ b/public/chat/actions/create_investigation_action.tsx
@@ -257,10 +257,8 @@ export const createInvestigationAction = (
           symptom: args.symptom,
           index: args.index,
           timeRange: args.timeRange,
-          message: `Investigation created successfully. Reply the message exactly like
-          'A new Investigation <Name> has been created. \n\n
-          <summary of this investigation> \n\n
-          Click the above link to open and start to run it.'`,
+          message: `Investigation created successfully. Reply ONLY with this exact format, do NOT add any extra description or elaboration:
+          '✅ Investigation **<Name>** created.\n\n**Goal:** <repeat the user's original goal exactly as they stated it, nothing more>\n\n👉 Click the above link to open and start running it.'`,
         };
       } catch (error) {
         return {


### PR DESCRIPTION
### Description
Improve investigation creation UX and LLM response message:
- Optimize LLM response message to only restate the user's goal without fabricating analysis or conclusions
- Show "Preparing investigation..." header during streaming, hide action buttons until data is ready
- Disable confirm/cancel/edit buttons after click to prevent duplicate actions
- Always show investigation link panel after creation

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).