### PR TITLE
[Navigation] Add icon side nav branching for investigation notebooks

### DIFF
--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -13,6 +13,9 @@ describe('registerAllPluginNavGroups', () => {
   beforeEach(() => {
     coreSetup = coreMock.createSetup();
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+      coreSetup.chrome.getIsIconSideNavEnabled = jest.fn();
+    }
   });
 
   it('should register investigation notebooks in observability nav group', () => {

--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../../src/core/public/mocks';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/public';
+import { registerAllPluginNavGroups } from './plugin_nav';
+
+describe('registerAllPluginNavGroups', () => {
+  let coreSetup: ReturnType<typeof coreMock.createSetup>;
+
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup();
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+  });
+
+  it('should register investigation notebooks in observability nav group', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    registerAllPluginNavGroups(coreSetup as any);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const notebookCall = observabilityCalls.find((call: any) =>
+      call[1].some((link: any) => link.id === 'investigation-notebooks')
+    );
+    expect(notebookCall).toBeDefined();
+  });
+
+  it('should register with visualizeAndReport category when icon side nav is OFF', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    registerAllPluginNavGroups(coreSetup as any);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const notebookCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'investigation-notebooks' &&
+          link.category === DEFAULT_APP_CATEGORIES.visualizeAndReport
+      )
+    );
+    expect(notebookCall).toBeDefined();
+  });
+
+  it('should register with observabilityTools category and notebookApp icon when icon side nav is ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const notebookCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'investigation-notebooks' &&
+          link.category === DEFAULT_APP_CATEGORIES.observabilityTools &&
+          link.euiIconType === 'notebookApp'
+      )
+    );
+    expect(notebookCall).toBeDefined();
+  });
+
+  it('should always register in security-analytics and all nav groups', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const securityCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS['security-analytics'] &&
+        call[1].some((link: any) => link.id === 'investigation-notebooks')
+    );
+    expect(securityCall).toBeDefined();
+
+    const allCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.all &&
+        call[1].some((link: any) => link.id === 'investigation-notebooks')
+    );
+    expect(allCall).toBeDefined();
+  });
+});

--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { coreMock } from '../../../../src/core/public/mocks';
-import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/public';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/utils';
 import { registerAllPluginNavGroups } from './plugin_nav';
 
 describe('registerAllPluginNavGroups', () => {

--- a/public/plugin_helpers/plugin_nav.tsx
+++ b/public/plugin_helpers/plugin_nav.tsx
@@ -9,13 +9,24 @@ import { AppPluginStartDependencies } from '../types';
 import { DEFAULT_NAV_GROUPS, DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
 
 export function registerAllPluginNavGroups(core: CoreSetup<AppPluginStartDependencies>) {
-  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-    {
-      id: investigationNotebookID,
-      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
-      order: 400,
-    },
-  ]);
+  if (core.chrome.getIsIconSideNavEnabled()) {
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: investigationNotebookID,
+        category: DEFAULT_APP_CATEGORIES.observabilityTools,
+        order: 400,
+        euiIconType: 'notebookApp',
+      },
+    ]);
+  } else {
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: investigationNotebookID,
+        category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+        order: 400,
+      },
+    ]);
+  }
   core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS[`security-analytics`], [
     {
       id: investigationNotebookID,


### PR DESCRIPTION
## Summary

Adds icon side nav support for the investigation plugin's notebook registration in the Observability workspace.

**Changes:**
- Branch nav registration in `registerAllPluginNavGroups()` based on `core.chrome.getIsIconSideNavEnabled()`
- When icon side nav is **enabled**: register notebooks under `observabilityTools` category with `notebookApp` icon — this places them in the collapsible "Tools" section of the icon sidebar
- When icon side nav is **disabled**: register notebooks under `visualizeAndReport` category (existing behavior)
- Registration in `security-analytics` and `all` nav groups remains unchanged
- Add comprehensive unit tests for all registration paths

**Files changed:**
- `public/plugin_helpers/plugin_nav.tsx` — icon side nav branching with category and icon changes
- `public/plugin_helpers/plugin_nav.test.tsx` — new test file covering icon ON/OFF paths and cross-group registration

## Related Issue

opensearch-project/OpenSearch-Dashboards#11545

## Test plan
- [ ] Verify investigation notebooks appear under "Tools" section in icon side nav (Observability workspace)
- [ ] Verify investigation notebooks appear under "Visualize and Report" in default nav
- [ ] Verify notebooks still appear in Security Analytics and All nav groups
- [ ] Run unit tests: `yarn test --testPathPattern=plugin_nav`