### PR TITLE
fix: Skip log pattern paragraph for clusters below 2.19.0

### DIFF
--- a/common/constants/notebooks.ts
+++ b/common/constants/notebooks.ts
@@ -28,6 +28,8 @@ export const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS';
 
 export const NOTEBOOK_APP_NAME = 'investigate-notebook';
 
+export const LOG_PATTERN_MIN_SUPPORTED_VERSION = '2.19.0';
+
 export const OBSERVABILITY_VISUALIZATION_TYPE = 'observability-visualization';
 
 export const DASHBOARDS_VISUALIZATION_TYPE = 'visualization';

--- a/common/types/notebooks.ts
+++ b/common/types/notebooks.ts
@@ -39,6 +39,7 @@ export interface InvestigationTimeRange {
 
 export interface NotebookContext {
   dataSourceId?: string;
+  dataSourceVersion?: string;
   timeField?: string;
   index?: string;
   currentTime?: number; // the time when PPL been executed when trigger from discovery

--- a/common/utils/shared.test.ts
+++ b/common/utils/shared.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { get, dataSourceFilterFn } from './shared';
+import { get, dataSourceFilterFn, supportsLogPatternAnalysis } from './shared';
 import { SavedObject } from '../../../../src/core/public';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 
@@ -191,6 +191,29 @@ describe('shared utils', () => {
         references: [],
       };
       expect(dataSourceFilterFn(dataSource)).toBe(false);
+    });
+  });
+
+  describe('supportsLogPatternAnalysis', () => {
+    it('should return true when version is undefined', () => {
+      expect(supportsLogPatternAnalysis(undefined)).toBe(true);
+    });
+
+    it('should return true for version >= 2.19.0', () => {
+      expect(supportsLogPatternAnalysis('2.19.0')).toBe(true);
+      expect(supportsLogPatternAnalysis('2.20.0')).toBe(true);
+      expect(supportsLogPatternAnalysis('3.0.0')).toBe(true);
+    });
+
+    it('should return false for version < 2.19.0', () => {
+      expect(supportsLogPatternAnalysis('2.18.0')).toBe(false);
+      expect(supportsLogPatternAnalysis('2.9.0')).toBe(false);
+      expect(supportsLogPatternAnalysis('1.0.0')).toBe(false);
+    });
+
+    it('should handle version with pre-release suffix', () => {
+      expect(supportsLogPatternAnalysis('2.19.0-SNAPSHOT')).toBe(true);
+      expect(supportsLogPatternAnalysis('2.18.0-SNAPSHOT')).toBe(false);
     });
   });
 });

--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -7,6 +7,7 @@ import semver from 'semver';
 import { SavedObject } from '../../../../src/core/public';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 import * as pluginManifest from '../../opensearch_dashboards.json';
+import { LOG_PATTERN_MIN_SUPPORTED_VERSION } from '../../common/constants/notebooks';
 
 /**
  * TODO making this method type-safe is nontrivial: if you just define
@@ -19,6 +20,13 @@ export function get<T = unknown>(obj: Record<string, any>, path: string, default
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return path.split('.').reduce((acc: any, part: string) => acc && acc[part], obj) || defaultValue;
 }
+
+export const supportsLogPatternAnalysis = (dataSourceVersion: string | undefined): boolean => {
+  if (!dataSourceVersion) return true;
+  const coerced = semver.coerce(dataSourceVersion);
+  if (!coerced) return true;
+  return semver.gte(coerced, LOG_PATTERN_MIN_SUPPORTED_VERSION, { loose: true });
+};
 
 export const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>) => {
   const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';

--- a/public/components/notebooks/components/__tests__/classic_notebook.test.tsx
+++ b/public/components/notebooks/components/__tests__/classic_notebook.test.tsx
@@ -56,6 +56,11 @@ jest.mock('react-router-dom', () => ({
   Redirect: ({ to }: { to: string }) => <div data-testid="redirect" data-to={to} />,
 }));
 
+jest.mock('../../../../utils/data_source_utils', () => ({
+  getDataSourceVersion: jest.fn(() => Promise.resolve(undefined)),
+  getDataSourceById: jest.fn(() => Promise.resolve({ id: 'test', title: 'test' })),
+}));
+
 jest.mock('../data_distribution/data_distribution_container', () => ({
   DataDistributionContainer: () => <div />,
 }));

--- a/public/hooks/use_notebook.tsx
+++ b/public/hooks/use_notebook.tsx
@@ -18,6 +18,7 @@ import { isValidUUID } from '../components/notebooks/components/helpers/notebook
 import { useOpenSearchDashboards } from '../../../../src/plugins/opensearch_dashboards_react/public';
 import { callOpenSearchCluster } from '../plugin_helpers/plugin_proxy_call';
 import { parsePPLQuery } from '../../common/utils';
+import { getDataSourceVersion } from '../utils/data_source_utils';
 
 export const useNotebook = () => {
   const context = useContext(NotebookReactContext);
@@ -128,6 +129,17 @@ export const useNotebook = () => {
           indexInsight,
         };
       }
+
+      if (!contextPayload.dataSourceVersion) {
+        const version = await getDataSourceVersion(http, res.context?.dataSourceId);
+        if (version) {
+          contextPayload = { ...contextPayload, dataSourceVersion: version };
+          updateNotebookContext({ dataSourceVersion: version }).catch((err) =>
+            console.error('Failed to save dataSourceVersion:', err)
+          );
+        }
+      }
+
       return {
         ...res,
         vizPrefix: res.vizPrefix || '',
@@ -142,7 +154,7 @@ export const useNotebook = () => {
     });
 
     return promise;
-  }, [context.state, http, showParagraphRunning, fetchIndexInsights]);
+  }, [context.state, http, showParagraphRunning, fetchIndexInsights, updateNotebookContext]);
 
   const updateHypotheses = useCallback(
     async (

--- a/public/hooks/use_precheck.tsx
+++ b/public/hooks/use_precheck.tsx
@@ -33,6 +33,7 @@ import { useOpenSearchDashboards } from '../../../../src/plugins/opensearch_dash
 import { isDateAppenddablePPL, validatePPLQuery } from '../utils/query';
 import { createDashboardVizObject } from '../utils/visualization';
 import { getClient } from '../services';
+import { supportsLogPatternAnalysis } from '../../common/utils/shared';
 
 export const waitForPrecheckContexts = ({
   paragraphStates,
@@ -118,7 +119,7 @@ export const usePrecheck = () => {
         }> = [];
 
         // Validate PPL query if present before creating PPL-dependent paragraphs
-        const pplQueryFromVariables = res.context?.variables?.['pplQuery'] as string | undefined;
+        const pplQueryFromVariables = res.context?.variables?.pplQuery as string | undefined;
         let isPPLValid = true;
         if (pplQueryFromVariables) {
           const validationResult = await validatePPLQuery({
@@ -131,8 +132,12 @@ export const usePrecheck = () => {
           }
         }
 
-        // Collect log pattern paragraph (only if PPL is valid)
-        if (!logPatternParaExists && isPPLValid) {
+        // Collect log pattern paragraph (only if PPL is valid and version supports it)
+        if (
+          !logPatternParaExists &&
+          isPPLValid &&
+          supportsLogPatternAnalysis(state.value.context.value?.dataSourceVersion)
+        ) {
           const resContext = res.context as NotebookContext;
           if (resContext?.timeRange && resContext?.index && resContext?.timeField) {
             if (
@@ -181,7 +186,7 @@ export const usePrecheck = () => {
             [NoteBookSource.DISCOVER, NoteBookSource.VISUALIZATION, NoteBookSource.CHAT].includes(
               resContext?.source!
             ) &&
-            resContext?.variables?.['pplQuery'] &&
+            resContext?.variables?.pplQuery &&
             !resContext.variables?.log &&
             isDateAppenddablePPL(resContext.variables.pplQuery);
 
@@ -196,7 +201,7 @@ export const usePrecheck = () => {
               timeField: resContext.timeField,
               dataSourceId: resContext?.dataSourceId,
               timeRange: resContext.timeRange,
-              query: resContext.variables?.['pplQuery'],
+              query: resContext.variables?.pplQuery,
             });
             paragraphsToCreate.push({
               input: {
@@ -214,12 +219,12 @@ export const usePrecheck = () => {
           (res.context?.source === NoteBookSource.DISCOVER ||
             res.context?.source === NoteBookSource.CHAT) &&
           !res.paragraphs.find((paragraph) => getInputType(paragraph) === PPL_PARAGRAPH_TYPE) &&
-          res.context.variables?.['pplQuery'] &&
+          res.context.variables?.pplQuery &&
           res.context.timeField &&
           res.context.timeRange
         ) {
           const formatToLocalTime = (timestamp: number) => moment(timestamp).format(dateFormat);
-          const pplQuery = res.context.variables?.['pplQuery'];
+          const pplQuery = res.context.variables?.pplQuery;
           paragraphsToCreate.push({
             input: {
               inputText: `%ppl ${pplQuery}`,
@@ -244,7 +249,7 @@ export const usePrecheck = () => {
           !res.paragraphs.find(
             (paragraph) => getInputType(paragraph) === DASHBOARDS_VISUALIZATION_TYPE
           ) &&
-          res.context.variables?.['savedObjectId'] &&
+          res.context.variables?.savedObjectId &&
           res.context.timeRange
         ) {
           const formatToLocalTime = (timestamp: number) => moment(timestamp).format(dateFormat);

--- a/public/utils/data_source_utils.ts
+++ b/public/utils/data_source_utils.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SavedObjectsClientContract } from '../../../../src/core/public';
+import { HttpStart, SavedObjectsClientContract } from '../../../../src/core/public';
+import { callOpenSearchCluster } from '../plugin_helpers/plugin_proxy_call';
 
 /**
  * Get data source by ID
@@ -30,5 +31,25 @@ export async function getDataSourceById(
   } catch (error) {
     console.error('Error fetching data source:', error);
     throw error;
+  }
+}
+
+export async function getDataSourceVersion(
+  http: HttpStart,
+  dataSourceId?: string
+): Promise<string | undefined> {
+  try {
+    const response: any = await callOpenSearchCluster({
+      http,
+      dataSourceId,
+      request: {
+        path: '/',
+        method: 'GET',
+      },
+    });
+    return response?.version?.number;
+  } catch (error) {
+    console.error('Error fetching data source version:', error);
+    return undefined;
   }
 }


### PR DESCRIPTION
### Description
Skip log pattern paragraph generation on OpenSearch clusters older than 2.19.0, which lack the ML features required for log pattern analysis. The cluster version is fetched and persisted in the notebook context for use during precheck.

### Issues Resolved
Prevents execution failures when log pattern paragraphs are generated against unsupported cluster versions.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).