### PR TITLE
[Security] Bump dompurify to 3.4.5 to resolve CVE-2025-15599

### DIFF
--- a/release-notes/opensearch-dashboards-investigation.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-dashboards-investigation.release-notes-3.7.0.0.md
@@ -1,0 +1,7 @@
+## Version 3.7.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
+
+### Security
+
+* Bump dompurify from 3.4.1 to 3.4.5 to resolve CVE-2025-15599

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,9 +535,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dompurify@^3.3.2:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.1.tgz#521d04483ac12631b2aedf434a5f5390933b8789"
-  integrity sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.5.tgz#bedc7d30a6007ae9a8937b952be6adb76a28e871"
+  integrity sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Description

Upgrades dompurify from 3.4.1 to 3.4.5 to fix CVE-2025-15599 (XSS bypass vulnerability).

## Remediation approach

**Escalation level:** Lockfile refresh (level 1 — least invasive)

The existing `^3.3.2` range in package.json already covers the patched version 3.4.5, so only the yarn.lock entry needed to be refreshed. No package.json changes required.

## Changes

- `yarn.lock` — dompurify 3.4.1 → 3.4.5
- Added 3.7.0.0 release notes with Security section

## Testing

Lockfile-only change; no API or behavior changes. The upgrade is a patch version within the existing semver range.

## References

- https://advisories.opensearch.org/advisory/CVE-2025-15599