### PR TITLE
fix: hide investigation features for AnalyticEngine data sources

### DIFF
--- a/public/actions/start_investigation_action.tsx
+++ b/public/actions/start_investigation_action.tsx
@@ -16,6 +16,7 @@ import {
 } from './start_investigation_from_discover_visualization_component';
 import { StartInvestigateModalDedentServices } from '../components/notebooks/components/discover_explorer/start_investigation_modal';
 import { investigationNotebookID } from '../../common/constants/shared';
+import { isAnalyticEngineDataSource } from '../utils/data_source_utils';
 
 export const ACTION_START_INVESTIGATION = 'startInvestigationAction';
 
@@ -51,7 +52,15 @@ export class StartInvestigationAction implements Action<ActionContext> {
   public async isCompatible({ embeddable }: ActionContext) {
     // Show for new discover visualizations
     // and not show the `start investigation` action in notebook.
-    return embeddable.type === 'explore' && this.currentAppId !== investigationNotebookID;
+    if (!(embeddable.type === 'explore' && this.currentAppId !== investigationNotebookID)) {
+      return false;
+    }
+    // Hide for AnalyticEngine data sources
+    const visEmbeddable = embeddable as DiscoverVisualizationEmbeddable;
+    const dsType = visEmbeddable.savedExplore?.searchSource?.getFields()?.query?.dataset?.dataSource
+      ?.type;
+    if (isAnalyticEngineDataSource(dsType)) return false;
+    return true;
   }
 
   public async execute({ embeddable }: ActionContext) {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -61,6 +61,7 @@ import { createInvestigateLogActionComponent } from './components/notebooks/comp
 import { StartInvestigateButton } from './components/notebooks/components/discover_explorer/start_investigate_button';
 import { createInvestigationAction } from './chat/actions/create_investigation_action';
 import { registerInvestigateCommand } from './chat/command/investigate_command';
+import { isAnalyticEngineDataSource } from './utils/data_source_utils';
 
 export class InvestigationPlugin
   implements
@@ -171,6 +172,7 @@ export class InvestigationPlugin
       if (!services.application?.capabilities.investigation.agenticFeaturesEnabled) {
         return;
       }
+
       setupDeps.explore?.logActionRegistry?.registerAction?.({
         id: 'investigate-single',
         displayName: i18n.translate('investigate.logAction.investigate-single', {
@@ -178,7 +180,9 @@ export class InvestigationPlugin
         }),
         iconType: 'notebookApp',
         order: 100,
-        isCompatible: () => true,
+        isCompatible: (context) => {
+          return !isAnalyticEngineDataSource(context.metadata?.dataSourceEngineType);
+        },
         component: createInvestigateLogActionComponent({
           services,
         }),
@@ -214,13 +218,13 @@ export class InvestigationPlugin
                   )?.content;
                   const output = context.currentMessage?.content;
 
-                  const notebookId = context.pageContext?.['notebookId'];
+                  const notebookId = context.pageContext?.notebookId;
 
                   if (input && output) {
                     try {
                       await findingService.addFinding(input, output, notebookId);
                       return true;
-                    } catch (error) {
+                    } catch {
                       // Return false to indicate failure to the suggestion system
                       return false;
                     }
@@ -263,6 +267,9 @@ export class InvestigationPlugin
         id: 'start-investigate-all',
         order: 10,
         slotType: 'resultsActionBar',
+        isCompatible: (context) => {
+          return !isAnalyticEngineDataSource(context.dataSourceEngineType);
+        },
         render: () => {
           return (
             <OpenSearchDashboardsContextProvider

--- a/public/utils/data_source_utils.test.ts
+++ b/public/utils/data_source_utils.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isAnalyticEngineDataSource } from './data_source_utils';
+
+describe('isAnalyticEngineDataSource', () => {
+  it('should return true when type is AnalyticEngine', () => {
+    expect(isAnalyticEngineDataSource('AnalyticEngine')).toBe(true);
+  });
+
+  it('should return false when type is OpenSearch', () => {
+    expect(isAnalyticEngineDataSource('OpenSearch')).toBe(false);
+  });
+
+  it('should return false when type is undefined', () => {
+    expect(isAnalyticEngineDataSource(undefined)).toBe(false);
+  });
+});

--- a/public/utils/data_source_utils.ts
+++ b/public/utils/data_source_utils.ts
@@ -53,3 +53,10 @@ export async function getDataSourceVersion(
     return undefined;
   }
 }
+
+/**
+ * Check if a data source type is AnalyticEngine (unsupported for AI features).
+ */
+export function isAnalyticEngineDataSource(dataSourceType: string | undefined): boolean {
+  return dataSourceType === 'AnalyticEngine';
+}


### PR DESCRIPTION
### Description
Fix investigation-related features showing for AnalyticEngine data sources which don't support OpenSearch DSL.

- Start Investigation embeddable action checks `dataset.dataSource.type` via `isAnalyticEngineDataSource()`
- Investigate-single log action checks `context.metadata.dataSourceEngineType`
- Start Investigation button uses slot registry `isCompatible(context)` to hide for AnalyticEngine
- Added `isAnalyticEngineDataSource` utility in `data_source_utils.ts` with unit tests

### Issues Resolved
Refs opensearch-project/OpenSearch-Dashboards#11882
Related: opensearch-project/OpenSearch-Dashboards#12083

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).