### PR TITLE
feat: upgrade dompurify to 3.4.7 to comply with OSD version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@algolia/autocomplete-theme-classic": "^1.2.1",
     "ajv": "^8.18.0",
     "autosize": "^6.0.1",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.7",
     "html2canvas-pro": "^1.6.6",
     "json5": "^2.2.3",
     "lru-cache": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,9 +541,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dompurify@^3.4.0:
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.6.tgz#8f73010d14a46cd9781bbd3630f3bcef025a2111"
-  integrity sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
+  integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
### Description
OSD upgrade dompurify to 3.4.7 in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12089 , this PR is to comply with the version.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
