### PR TITLE
feat: hide start investigation button for explore visualization with transformation

### DIFF
--- a/public/actions/__tests__/start_investigation_action.test.tsx
+++ b/public/actions/__tests__/start_investigation_action.test.tsx
@@ -50,6 +50,7 @@ describe('StartInvestigationAction', () => {
     // Setup mock embeddable
     mockEmbeddable = {
       type: 'explore',
+      savedExplore: { visualization: '{}' },
       getInput: jest.fn(),
       getOutput: jest.fn(),
       reload: jest.fn(),
@@ -85,45 +86,81 @@ describe('StartInvestigationAction', () => {
   });
 
   describe('isCompatible', () => {
-    it('should return true for explore type embeddables', async () => {
-      const embeddable = { type: 'explore' } as IEmbeddable;
-      const result = await action.isCompatible({ embeddable });
+    const makeEmbeddable = (type: string, visualization = '{}') =>
+      ({ type, savedExplore: { visualization } } as any);
+
+    it('should return true for explore type embeddables without dataTransformations', async () => {
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('explore') });
       expect(result).toBe(true);
     });
 
     it('should return false for non-explore type embeddables', async () => {
-      const embeddable = { type: 'visualization' } as IEmbeddable;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('visualization') });
       expect(result).toBe(false);
     });
 
     it('should return false for dashboard type embeddables', async () => {
-      const embeddable = { type: 'dashboard' } as IEmbeddable;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('dashboard') });
       expect(result).toBe(false);
     });
 
     it('should return false for lens type embeddables', async () => {
-      const embeddable = { type: 'lens' } as IEmbeddable;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('lens') });
       expect(result).toBe(false);
     });
 
     it('should return false for undefined type', async () => {
-      const embeddable = { type: undefined } as any;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable(undefined as any) });
       expect(result).toBe(false);
     });
 
     it('should return false for null type', async () => {
-      const embeddable = { type: null } as any;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable(null as any) });
       expect(result).toBe(false);
     });
 
     it('should return false for empty string type', async () => {
-      const embeddable = { type: '' } as any;
-      const result = await action.isCompatible({ embeddable });
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('') });
+      expect(result).toBe(false);
+    });
+
+    it('should return false when dataTransformations is non-empty', async () => {
+      const visualization = JSON.stringify({ dataTransformations: [{ type: 'filter' }] });
+      const result = await action.isCompatible({
+        embeddable: makeEmbeddable('explore', visualization),
+      });
+      expect(result).toBe(false);
+    });
+
+    it('should return true when dataTransformations is empty array', async () => {
+      const visualization = JSON.stringify({ dataTransformations: [] });
+      const result = await action.isCompatible({
+        embeddable: makeEmbeddable('explore', visualization),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return true when dataTransformations is not present', async () => {
+      const visualization = JSON.stringify({ someOtherField: 'value' });
+      const result = await action.isCompatible({
+        embeddable: makeEmbeddable('explore', visualization),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return true when visualization is invalid JSON', async () => {
+      const result = await action.isCompatible({
+        embeddable: makeEmbeddable('explore', 'not-json'),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when in investigation notebook app', async () => {
+      (mockServices.application.currentAppId$ as BehaviorSubject<string | undefined>).next(
+        'investigation-notebooks'
+      );
+      action = new StartInvestigationAction(mockOverlay, mockServices);
+      const result = await action.isCompatible({ embeddable: makeEmbeddable('explore') });
       expect(result).toBe(false);
     });
   });

--- a/public/actions/start_investigation_action.tsx
+++ b/public/actions/start_investigation_action.tsx
@@ -21,7 +21,7 @@ import { isAnalyticEngineDataSource } from '../utils/data_source_utils';
 export const ACTION_START_INVESTIGATION = 'startInvestigationAction';
 
 interface ActionContext {
-  embeddable: IEmbeddable;
+  embeddable: IEmbeddable & { savedExplore: { visualization: string } };
 }
 
 export class StartInvestigationAction implements Action<ActionContext> {
@@ -50,9 +50,24 @@ export class StartInvestigationAction implements Action<ActionContext> {
   }
 
   public async isCompatible({ embeddable }: ActionContext) {
+    const isExplore = embeddable.type === 'explore';
     // Show for new discover visualizations
     // and not show the `start investigation` action in notebook.
-    if (!(embeddable.type === 'explore' && this.currentAppId !== investigationNotebookID)) {
+    if (!(isExplore && this.currentAppId !== investigationNotebookID)) {
+      return false;
+    }
+
+    let hasTransformation = false;
+    try {
+      const visualizationObject = JSON.parse(embeddable.savedExplore.visualization) as {
+        dataTransformations?: [];
+      };
+      hasTransformation = !!visualizationObject.dataTransformations?.length;
+    } catch (_e) {
+      console.warn('Invalid visualization string');
+    }
+
+    if (hasTransformation) {
       return false;
     }
     // Hide for AnalyticEngine data sources


### PR DESCRIPTION
### Description
hide start investigation button for explore visualization with transformation

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
