### PR TITLE
feat: disable create_investigation tool on search relevance page

### DIFF
--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { createInvestigationAction } from './chat/actions/create_investigation_action';
+import { registerInvestigateCommand } from './chat/command/investigate_command';
+import { coreStartMock } from '../test/__mocks__/coreMocks';
+
+/**
+ * Tests the create_investigation tool disable/enable logic based on currentAppId$.
+ * This mirrors the subscription in InvestigationPlugin.start().
+ */
+describe('create_investigation tool page-based availability', () => {
+  let currentAppId$: BehaviorSubject<string | undefined>;
+  let registerAssistantAction: jest.Mock;
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+    registerAssistantAction = jest.fn();
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+  });
+
+  const setupSubscription = () => {
+    const investigationAction = createInvestigationAction(coreStartMock);
+    registerAssistantAction(investigationAction);
+
+    subscription = currentAppId$.subscribe((appId) => {
+      if (appId === 'searchRelevance') {
+        registerAssistantAction({ ...investigationAction, available: 'disabled' });
+      } else {
+        registerAssistantAction(investigationAction);
+      }
+    });
+
+    return investigationAction;
+  };
+
+  it('should register the action initially', () => {
+    setupSubscription();
+
+    expect(registerAssistantAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'create_investigation' })
+    );
+  });
+
+  it('should disable create_investigation when appId is searchRelevance', () => {
+    setupSubscription();
+    registerAssistantAction.mockClear();
+
+    currentAppId$.next('searchRelevance');
+
+    expect(registerAssistantAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'create_investigation',
+        available: 'disabled',
+      })
+    );
+  });
+
+  it('should enable create_investigation when navigating away from searchRelevance', () => {
+    setupSubscription();
+    currentAppId$.next('searchRelevance');
+    registerAssistantAction.mockClear();
+
+    currentAppId$.next('explore');
+
+    expect(registerAssistantAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'create_investigation' })
+    );
+    expect(registerAssistantAction).not.toHaveBeenCalledWith(
+      expect.objectContaining({ available: 'disabled' })
+    );
+  });
+
+  it('should not fire after unsubscribe', () => {
+    setupSubscription();
+    subscription.unsubscribe();
+    registerAssistantAction.mockClear();
+
+    currentAppId$.next('searchRelevance');
+
+    expect(registerAssistantAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('/investigate command page-based availability', () => {
+  let currentAppId$: BehaviorSubject<string | undefined>;
+  let mockRegisterCommand: jest.Mock;
+  let mockUnregister: jest.Mock;
+  let chatSetup: any;
+  let unregisterCommand: (() => void) | undefined;
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+    mockUnregister = jest.fn();
+    mockRegisterCommand = jest.fn().mockReturnValue(mockUnregister);
+    chatSetup = { commandRegistry: { registerCommand: mockRegisterCommand } };
+    unregisterCommand = registerInvestigateCommand(chatSetup);
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+  });
+
+  const setupSubscription = () => {
+    subscription = currentAppId$.subscribe((appId) => {
+      if (appId === 'searchRelevance') {
+        if (unregisterCommand) {
+          unregisterCommand();
+          unregisterCommand = undefined;
+        }
+      } else {
+        if (!unregisterCommand) {
+          unregisterCommand = registerInvestigateCommand(chatSetup);
+        }
+      }
+    });
+  };
+
+  it('should unregister /investigate command on searchRelevance page', () => {
+    setupSubscription();
+
+    currentAppId$.next('searchRelevance');
+
+    expect(mockUnregister).toHaveBeenCalled();
+    expect(unregisterCommand).toBeUndefined();
+  });
+
+  it('should re-register /investigate command when leaving searchRelevance', () => {
+    setupSubscription();
+    currentAppId$.next('searchRelevance');
+    mockRegisterCommand.mockClear();
+
+    currentAppId$.next('explore');
+
+    expect(mockRegisterCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'investigate' })
+    );
+    expect(unregisterCommand).toBeDefined();
+  });
+
+  it('should not re-register if already registered', () => {
+    setupSubscription();
+    mockRegisterCommand.mockClear();
+
+    currentAppId$.next('explore');
+
+    expect(mockRegisterCommand).not.toHaveBeenCalled();
+  });
+
+  it('should not unregister if already unregistered', () => {
+    setupSubscription();
+    currentAppId$.next('searchRelevance');
+    mockUnregister.mockClear();
+
+    currentAppId$.next('searchRelevance');
+
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+});

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -5,7 +5,7 @@
 
 import { i18n } from '@osd/i18n';
 import React from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 import {
   AppMountParameters,
@@ -62,6 +62,7 @@ import { StartInvestigateButton } from './components/notebooks/components/discov
 import { createInvestigationAction } from './chat/actions/create_investigation_action';
 import { registerInvestigateCommand } from './chat/command/investigate_command';
 import { isAnalyticEngineDataSource } from './utils/data_source_utils';
+import { ChatPluginSetup } from '../../../src/plugins/chat/public';
 
 export class InvestigationPlugin
   implements
@@ -71,6 +72,8 @@ export class InvestigationPlugin
   private telemetryRecorder: PluginTelemetryRecorder | undefined;
   private startDeps: AppPluginStartDependencies | undefined;
   private unregisterInvestigateCommand?: () => void;
+  private appIdSubscription?: Subscription;
+  private chatSetup?: ChatPluginSetup;
 
   private appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
 
@@ -239,6 +242,7 @@ export class InvestigationPlugin
     })();
 
     // Register /investigate command if chat plugin is available
+    this.chatSetup = setupDeps.chat;
     this.unregisterInvestigateCommand = registerInvestigateCommand(setupDeps.chat);
 
     // Return methods that should be available to other plugins
@@ -286,9 +290,29 @@ export class InvestigationPlugin
       });
 
       // create investigation action
-      this.startDeps?.contextProvider?.actions?.registerAssistantAction?.(
-        createInvestigationAction(core)
-      );
+      const investigationAction = createInvestigationAction(core);
+      const registerAction = this.startDeps?.contextProvider?.actions?.registerAssistantAction;
+      registerAction?.(investigationAction);
+
+      // Disable create_investigation tool and /investigate command on the search-relevance page
+      this.appIdSubscription = core.application.currentAppId$.subscribe((appId) => {
+        if (appId === 'searchRelevance') {
+          if (registerAction) {
+            registerAction({ ...investigationAction, available: 'disabled' });
+          }
+          if (this.unregisterInvestigateCommand) {
+            this.unregisterInvestigateCommand();
+            this.unregisterInvestigateCommand = undefined;
+          }
+        } else {
+          if (registerAction) {
+            registerAction(investigationAction);
+          }
+          if (this.chatSetup && !this.unregisterInvestigateCommand) {
+            this.unregisterInvestigateCommand = registerInvestigateCommand(this.chatSetup);
+          }
+        }
+      });
       // Register "Start investigation" action for discover visualizations
       const startInvestigationAction = new StartInvestigationAction(core.overlays, {
         data: startDeps.data,
@@ -320,11 +344,12 @@ export class InvestigationPlugin
   };
 
   public stop() {
+    this.appIdSubscription?.unsubscribe();
+
     // Unregister the /investigate command
     if (this.unregisterInvestigateCommand) {
       this.unregisterInvestigateCommand();
     }
-
     this.telemetryRecorder = undefined;
   }
 }


### PR DESCRIPTION
### Description
Disables the `create_investigation` assistant tool when the user is on the Search Relevance page, since creating investigations is not relevant in that context.

The change subscribes to `core.application.currentAppId$` and sets `available: "disabled"` on the action when the active app is `searchRelevance`, preventing it from being sent to the agent. The tool is re-enabled when navigating to any other page. The subscription is properly cleaned up in `stop()` to prevent memory leaks.

### Issues Resolved
N/A - feature improvement to reduce irrelevant tool suggestions in chat

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).