### PR TITLE
Add Notebooks navPopover to the icon side navigation

### DIFF
--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -225,10 +225,14 @@ export function NoteTable({ deleteNotebook }: NoteTableProps) {
 
   useEffect(() => {
     const url = window.location.hash.split('/');
-    if (url[url.length - 1] === 'create') {
+    // Open the create-notebook modal on the `#/create` route. Guard on
+    // `!isModalVisible` so a repeat navigation to `#/create` (e.g. clicking the
+    // side-nav "Create notebook" popover action again while the modal is already
+    // open) doesn't stack a second modal on top of the first.
+    if (url[url.length - 1] === 'create' && !isModalVisible) {
       createNote();
     }
-  }, [location, createNote]);
+  }, [location, createNote, isModalVisible]);
 
   const deleteNote = () => {
     setModalLayout(

--- a/public/plugin_helpers/notebooks_nav_popover.ts
+++ b/public/plugin_helpers/notebooks_nav_popover.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { NavPopoverConfig } from '../../../../src/core/public';
+import { investigationNotebookID } from '../../common/constants/shared';
+
+/**
+ * Nav-item popover for the Investigation Notebooks icon-side-nav item: quick
+ * actions to create a new notebook (the app auto-opens the create flow on
+ * `#/create`) or view the full notebooks list (`#/`). The item still navigates
+ * to Notebooks on direct click.
+ */
+export const notebooksNavPopover: NavPopoverConfig = {
+  actions: [
+    {
+      id: 'createNotebook',
+      label: i18n.translate('investigation.navPopover.createNotebook', {
+        defaultMessage: 'Create notebook',
+      }),
+      iconType: 'plusInCircle',
+      onClick: ({ navigateToApp }) => navigateToApp(investigationNotebookID, { path: '#/create' }),
+    },
+    {
+      id: 'viewAllNotebooks',
+      label: i18n.translate('investigation.navPopover.viewAllNotebooks', {
+        defaultMessage: 'View all notebooks',
+      }),
+      iconType: 'list',
+      onClick: ({ navigateToApp }) => navigateToApp(investigationNotebookID, { path: '#/' }),
+    },
+  ],
+};

--- a/public/plugin_helpers/plugin_nav.tsx
+++ b/public/plugin_helpers/plugin_nav.tsx
@@ -7,6 +7,7 @@ import { investigationNotebookID } from '../../common/constants/shared';
 import { CoreSetup } from '../../../../src/core/public';
 import { AppPluginStartDependencies } from '../types';
 import { DEFAULT_NAV_GROUPS, DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
+import { notebooksNavPopover } from './notebooks_nav_popover';
 
 export function registerAllPluginNavGroups(core: CoreSetup<AppPluginStartDependencies>) {
   if (core.chrome.getIsIconSideNavEnabled()) {
@@ -16,6 +17,7 @@ export function registerAllPluginNavGroups(core: CoreSetup<AppPluginStartDepende
         category: DEFAULT_APP_CATEGORIES.observabilityTools,
         order: 400,
         euiIconType: 'notebookApp',
+        navPopover: notebooksNavPopover,
       },
     ]);
   } else {


### PR DESCRIPTION
### Description

This change attaches a hover popover (navPopover) to the Notebooks item in the icon side navigation, building on the navPopover system added in OpenSearch Dashboards core.

The popover adds two actions:

- Create notebook, which navigates to #/create and auto opens the create modal
- View all notebooks, which navigates to the notebooks list

It also guards the note table #/create effect on the modal not already being visible, so a repeat navigation to #/create (for example clicking the popover action again) does not stack a second create modal.

Note: this depends on the navPopover types from the corresponding OpenSearch Dashboards core PR, so it should be merged after that core change is available.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
