### PR TITLE
Prompt refactor for planner agent (investigation)

### DIFF
--- a/server/routes/notebooks/agent_router.ts
+++ b/server/routes/notebooks/agent_router.ts
@@ -8,45 +8,7 @@ import { IOpenSearchDashboardsResponse, IRouter } from '../../../../../src/core/
 import { NOTEBOOKS_API_PREFIX } from '../../../common/constants/notebooks';
 import { getOpenSearchClientTransport, handleError } from '../utils';
 
-const commonInstructions = `
-# Instructions
-
-## Core Planning Rules
-- Break the objective into an ordered list of atomic, self-contained Steps that, if executed, will lead to the final result or complete the objective
-- Each Step must state what to do, where, and which tool/parameters would be used. You do not execute tools, only reference them for planning
-- Use only the provided tools; do not invent or assume tools. If no suitable tool applies, use reasoning or observations instead
-- Base your plan only on the data and information explicitly provided; do not rely on unstated knowledge or external facts
-- If there is insufficient information to create a complete plan, summarize what is known so far and clearly state what additional information is required to proceed
-- Stop and summarize if the task is complete or further progress is unlikely
-- Avoid vague instructions; be specific about data sources, indexes, or parameters
-- Never make assumptions or rely on implicit knowledge
-- Respond only in JSON format
-${/* Avoid too many tokens when it is an index pattern */ ''}
-- When using ListIndexTool, use include_details false when the input is an index pattern or wildcard.
-
-## Step Examples
-**Good example:** "Use Tool to sample documents from index: 'my-index'"
-
-**Bad example:** "Use Tool to sample documents from each index"
-
-**Bad example:** "Use Tool to sample documents from all indices"`;
-
-const commonResponseFormat = `
-# Response Format
-
-## JSON Response Requirements
-Only respond in JSON format. Always follow the given response instructions. Do not return any content that does not follow the response instructions. Do not add anything before or after the expected JSON
-
-Always respond with a valid JSON object that strictly follows the below schema:
-\`\`\`json
-{
-  "steps": array[string],
-  "result": string
-}
-\`\`\`
-
-- Use "steps" to return an array of strings where each string is a step to complete the objective, leave it empty if you know the final result. Please wrap each step in quotes and escape any special characters within the string
-- Use "result" to return the final response when you have enough information, leave it empty if you want to execute more steps. When providing the final result, it MUST be a stringified JSON object with the following structure:
+const resultExpandAndOverride = `When providing the final result, it MUST be a stringified JSON object with the following structure:
 
 ## Final Result Structure
 Final result must be a stringified JSON object:
@@ -77,6 +39,13 @@ Your final result JSON must include:
   * **"traceId"**: The trace ID associated with this topology
   * **"hypothesisIds"**: Array of hypothesis IDs that this topology supports
   * **"nodes"**: Array of node objects representing services/operations
+  **"Topology Node Requirements"**
+  * **Each node represents a service or operation in the trace
+  * **Use parentId to establish hierarchy (null for root nodes)
+  * **Include precise startTime (ISO format) and duration
+  * **Provide descriptive status (e.g., "success", "failed", "error", "latency", "timeout", etc.)
+  * **Keep focused on critical path (limit to 10 nodes max)
+
 
 ### Finding Structure
 \`\`\`json
@@ -139,22 +108,16 @@ Your final result JSON must include:
 }
 \`\`\`
 
-## Critical Rules
-1. Do not use commas within individual steps
-2. **CRITICAL: For tool parameters use commas without spaces (e.g., "param1,param2,param3") - This rule must be followed exactly**
-3. For individual steps that call a specific tool, include all required parameters
-4. Do not add any content before or after the JSON
-5. Only respond with a pure JSON object
-6. **CRITICAL: The "result" field in your final response MUST contain a properly escaped JSON string**
-7. **CRITICAL: The hypothesis must reference specific findings by their IDs in the supporting_findings array**
-8. **Topology Generation Rule:** When trace data with traceId is available, create a single topology object in the "topologies" array with structured node data. Generate only one topology with the most critical service call hierarchy in JSON format.
+`;
 
-### Topology Node Requirements:
-- Each node represents a service or operation in the trace
-- Use parentId to establish hierarchy (null for root nodes)
-- Include precise startTime (ISO format) and duration
-- Provide descriptive status (e.g., "success", "failed", "error", "latency", "timeout", etc.)
-- Keep focused on critical path (limit to 10 nodes max)
+const importantRulesExpand = `
+4. For individual steps that call a specific tool, include all required parameters
+5. **CRITICAL: The "result" field in your final response MUST contain a properly escaped JSON string**
+6. **CRITICAL: The hypothesis must reference specific findings by their IDs in the supporting_findings array**
+7. **Topology Generation Rule:** When trace data with traceId is available, create a single topology object in the "topologies" array with structured node data. Generate only one topology with the most critical service call hierarchy in JSON format
+8. ${
+  /* Avoid too many tokens when it is an index pattern */ ''
+}\\n When using ListIndexTool, use include_details false when the input is an index pattern or wildcard.
 
 `;
 
@@ -197,22 +160,9 @@ export function registerAgentExecutionRoute(router: IRouter) {
         const { initialGoal, timeRange, prevContent, question } = parameters;
         const { agentId } = request.params;
         const { async } = request.query;
-        let systemPrompt;
+        const isReInvestigation = prevContent && !!initialGoal;
 
-        if (prevContent && !!initialGoal) {
-          systemPrompt = `
-# Re-Investigation Agent
-
-You are a thoughtful and analytical planner agent specializing in **RE-INVESTIGATION**. Your job is to update existing hypotheses based on current evidence while minimizing new findings creation.
-${getTimeScopePrompt(timeRange)}
-## Investigation Context
-**ORIGINAL QUESTION:** "${initialGoal}"
-
-The hypotheses were generated from this original question.
-
-**NEW INVESTIGATION QUESTION:** "${question}"
-
-You are now investigating this new question. Update the hypotheses based on this new question and current evidence.
+        const reInvestigationRules = `
 
 ## Re-Investigation Rules
 - Analyze existing hypotheses and findings to determine if they remain valid
@@ -220,7 +170,6 @@ You are now investigating this new question. Update the hypotheses based on this
 - Only create **NEW** findings when absolutely necessary for novel evidence
 - Update hypothesis likelihood based on all available evidence
 
-${commonInstructions}
 
 ## User Feedback Handling Instructions
 **CRITICAL: Follow these rules when processing user feedback:**
@@ -259,22 +208,8 @@ You **MUST** include ONLY findings that are genuinely NEW. A finding is **NOT** 
 ## Operation Guidance
 Create new hypotheses with fresh IDs. Previous hypotheses will be replaced.
 
-${commonResponseFormat}
-
 **The final response should create a clear chain of evidence where findings support your hypothesis while maximizing reuse of existing evidence.**
 `.trim();
-        } else {
-          systemPrompt = `
-# Investigation Planner Agent
-
-You are a thoughtful and analytical planner agent in a plan-execute-reflect framework. Your job is to design a clear, step-by-step plan for a given objective.
-${getTimeScopePrompt(timeRange)}
-
-${commonInstructions}
-
-${commonResponseFormat}
-`.trim();
-        }
 
         const plannerPromptTemplate = `
 ## AVAILABLE TOOLS
@@ -282,6 +217,20 @@ ${commonResponseFormat}
 
 ## PLANNING GUIDANCE
 \${parameters.planner_prompt}
+
+
+${
+  isReInvestigation
+    ? `
+## Investigation Context
+**ORIGINAL QUESTION:** "${initialGoal}"
+
+**NEW INVESTIGATION QUESTION:** "${question}"`
+    : ''
+}
+
+## INVESTIGATION SCOPE
+**TIME RANGE:** ${getTimeScopePrompt(timeRange)}
 
 ## OBJECTIVE
 Your job is to fulfill user's requirements and answer their questions effectively. User Input:
@@ -342,6 +291,15 @@ You have already completed the following steps from the original plan. Consider 
 
 Remember: Respond only in JSON format following the required schema.`;
 
+        const plannerSystemPromptPrefix =
+          '# Investigation Planner Agent\n\nYou are a thoughtful and analytical planner agent in a plan-execute-reflect framework. Your job is to design a clear, step-by-step plan for a given objective.\n\n';
+
+        const reInvestigationPlannerSystemPromptPrefix =
+          '# Re-Investigation Agent\n\n' +
+          'You are a thoughtful and analytical planner agent specializing in **RE-INVESTIGATION**. Your job is to update existing hypotheses based on current evidence while minimizing new findings creation.\n\n' +
+          'The hypotheses were generated from this original question.\n\n' +
+          'You are now investigating this new question. Update the hypotheses based on this new question and current evidence.\n\n';
+
         const transport = await getOpenSearchClientTransport({
           context,
           request,
@@ -366,7 +324,13 @@ Remember: Respond only in JSON format following the required schema.`;
               context: parameters.context,
               executor_agent_memory_id: parameters.executor_agent_memory_id,
               question,
-              system_prompt: systemPrompt,
+              result_expand_and_override: resultExpandAndOverride,
+              important_rules_expand: isReInvestigation
+                ? importantRulesExpand + reInvestigationRules
+                : importantRulesExpand,
+              planner_system_prompt_prefix: isReInvestigation
+                ? reInvestigationPlannerSystemPromptPrefix
+                : plannerSystemPromptPrefix,
               planner_prompt_template: plannerPromptTemplate,
               planner_with_history_template: plannerWithHistoryTemplate,
               reflect_prompt_template: reflectPromptTemplate,


### PR DESCRIPTION
### Description
Prompt refactor for planner agent (investigation)

Currently, there are two sets of system prompt, one in investigation and one in ml-commons. The change is ONLY keep the common part of these two sets of system prompt into ml-commons, and keep the investigation-only system prompt in investigation, then pass investigation-only system prompt to ml-common to combine with/override/expend the common system prompt. 

Another change is to move the dynamic field(timeScope, currentTime, initial goal, new question) from system prompt to context to make the system prompt static.

This PR should work with https://github.com/opensearch-project/ml-commons/pull/4594.

investigation system prompt before and after diff:
<img width="2385" height="1225" alt="investigation system prompt diff" src="https://github.com/user-attachments/assets/fa8dc306-de81-4e85-9ee3-59ab2064ece6" />


re-investigation system prompt before and after diff:
<img width="2435" height="1171" alt="re-investigation system prompt diff" src="https://github.com/user-attachments/assets/e64ba9e9-ab7b-4f8c-8869-8395c6a34fad" />

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
