### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/chat/actions/components/__tests__/CreateInvestigatioToolResult.test.tsx
+++ b/public/chat/actions/components/__tests__/CreateInvestigatioToolResult.test.tsx
@@ -120,7 +120,7 @@ describe('CreateInvestigationToolResult', () => {
 
     // Check for link panel with URL (visible when collapsed)
     expect(
-      screen.getByText(/http:\/\/localhost\/app\/investigation-notebooks/)
+      screen.getByText(/http:\/\/localhost:5601\/app\/investigation-notebooks/)
     ).toBeInTheDocument();
   });
 
@@ -175,7 +175,7 @@ describe('CreateInvestigationToolResult', () => {
 
     // Link panel with URL should be visible again when collapsed
     expect(
-      screen.getByText(/http:\/\/localhost\/app\/investigation-notebooks/)
+      screen.getByText(/http:\/\/localhost:5601\/app\/investigation-notebooks/)
     ).toBeInTheDocument();
   });
 

--- a/public/components/notebooks/components/__tests__/__snapshots__/classic_notebook.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/classic_notebook.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Notebook /> spec Renders the empty component 1`] = `
 <div

--- a/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NoteTable /> spec renders the component 1`] = `
 <div

--- a/public/components/notebooks/components/__tests__/note_table.test.tsx
+++ b/public/components/notebooks/components/__tests__/note_table.test.tsx
@@ -138,10 +138,8 @@ describe('<NoteTable /> spec', () => {
       NotebookType: 'Agentic',
     }));
     const utils = await renderNoteTable({ notebooks });
-    fireEvent.click(utils.getByText('Create notebook'));
-    await waitFor(() => {
-      expect(global.window.location.href).toContain('/create');
-    });
+    // Under jsdom 26 clicking an anchor no longer navigates; assert the link target instead.
+    expect(utils.getByText('Create notebook').closest('a')).toHaveAttribute('href', '#/create');
   });
 
   it('filters notebooks based on search input', async () => {
@@ -167,12 +165,15 @@ describe('<NoteTable /> spec', () => {
   });
 
   it('displays empty state message and create notebook button', async () => {
+    // The "Create notebook" anchor points at #/create; a mount effect reads
+    // window.location.hash to open the modal. Under jsdom 26 an anchor click no longer
+    // navigates, so set the hash before render instead of clicking the link.
+    window.location.assign('#/create');
     const { getAllByText, getAllByTestId } = await renderNoteTable({ notebooks: [] });
 
     expect(getAllByText('No notebooks')).toHaveLength(1);
 
     // Create notebook using the modal
-    fireEvent.click(getAllByText('Create notebook')[0]);
     fireEvent.click(getAllByTestId('custom-input-modal-input')[0]);
     fireEvent.input(getAllByTestId('custom-input-modal-input')[0], {
       target: { value: 'test-notebook' },

--- a/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`modal_containers spec render delete notebooks modal 1`] = `
 <body

--- a/public/components/notebooks/components/helpers/__tests__/modal_containers.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/modal_containers.test.tsx
@@ -101,6 +101,6 @@ describe('modal_containers spec', () => {
       target: { value: 'delete' },
     });
     fireEvent.click(utils.getAllByTestId('delete-notebook-modal-delete-button')[0]);
-    expect(onConfirm).toBeCalled();
+    expect(onConfirm).toHaveBeenCalled();
   });
 });

--- a/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
@@ -20,7 +20,7 @@ describe('reporting_context_menu_helper tests', () => {
       assign: jest.fn(),
     };
     contextMenuViewReports();
-    expect(window.location.assign).toBeCalledWith('reports-dashboards#/');
+    expect(window.location.assign).toHaveBeenCalledWith('reports-dashboards#/');
     window.location = savedLocation;
   });
 
@@ -34,7 +34,7 @@ describe('reporting_context_menu_helper tests', () => {
       assign: jest.fn(),
     };
     contextMenuCreateReportDefinition('https://mock-base.uri/mock-base-path');
-    expect(window.location.assign).toBeCalledWith(
+    expect(window.location.assign).toHaveBeenCalledWith(
       'reports-dashboards#/create?previous=notebook:mock-base-path?timeFrom=0?timeTo=0'
     );
     window.location = savedLocation;
@@ -65,32 +65,41 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.csv', '__user__', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('generates pdf for global tenant', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.pdf', '', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('generates png for custom tenant', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('handles 404 error', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(404, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Download error',
       'danger',
       'There was an error generating this report.'
@@ -101,8 +110,8 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(403, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Error generating report,',
       'danger',
       'Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.'
@@ -113,8 +122,8 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(503, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Error generating report.',
       'danger',
       'Timed out generating on-demand report from notebook. Try again later.'
@@ -130,7 +139,7 @@ describe('reporting_context_menu_helper tests', () => {
     } catch (error) {
       expect(error.status).toEqual(500);
     }
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
   });
 });

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CustomInputModal /> spec renders the component 1`] = `
 <body

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/reporting_loading_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/reporting_loading_modal.test.tsx.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<GenerateReportLoadingModal /> spec renders the component 1`] = `<div />`;

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/reporting_loading_modal.test.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/reporting_loading_modal.test.tsx
@@ -13,6 +13,6 @@ describe('<GenerateReportLoadingModal /> spec', () => {
     const utils = render(<GenerateReportLoadingModal setShowLoading={setShowLoading} />);
     expect(utils.container.firstChild).toMatchSnapshot();
     utils.getByTestId('reporting-loading-modal-close-button').click();
-    expect(setShowLoading).toBeCalledWith(false);
+    expect(setShowLoading).toHaveBeenCalledWith(false);
   });
 });

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_query_grid.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_query_grid.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<QueryDataGridMemo /> spec renders the component 1`] = `
 <div

--- a/public/components/notebooks/components/paragraph_components/__tests__/paragraph.test.tsx
+++ b/public/components/notebooks/components/paragraph_components/__tests__/paragraph.test.tsx
@@ -111,10 +111,7 @@ const ContextAwareParagraphs = (
 describe('<Paragraph /> spec', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    Object.defineProperty(window, 'location', {
-      value: mockLocation,
-      writable: true,
-    });
+    window.location.assign(mockLocation.href);
   });
 
   it('renders classic notebook paragraph', () => {

--- a/test/__mocks__/rawLoaderMock.js
+++ b/test/__mocks__/rawLoaderMock.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Stub for `!!raw-loader!` imports. jest-raw-loader is incompatible with the
+// Jest 28+ transformer API and was removed during the Jest 30 upgrade. No test
+// asserts the real raw file contents (the only consumer mocks the import
+// directly), so a string stub preserves the prior behaviour.
+module.exports = 'raw-loader-stub';

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -8,7 +8,7 @@ process.env.TZ = 'UTC';
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   clearMocks: true,
@@ -25,7 +25,18 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',
     '\\@algolia/autocomplete-theme-classic$': '<rootDir>/test/__mocks__/styleMock.js',
-    '^!!raw-loader!.*': 'jest-raw-loader',
+    '^!!raw-loader!.*': '<rootDir>/test/__mocks__/rawLoaderMock.js',
   },
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -34,7 +34,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
 import { setOSDHttp, setOSDSavedObjectsClient } from '../common/utils';
 import { coreStartMock } from './__mocks__/coreMocks';
@@ -45,9 +45,15 @@ jest.setTimeout(30000);
 setOSDHttp(coreStartMock.http);
 setOSDSavedObjectsClient(coreStartMock.savedObjects.client);
 
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'
+// in all jsdom tests, consistent with the rest of the suite.
+process.env.HOST = 'http://localhost:5601';
+
 // Mock window.matchMedia for Monaco editor
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
+  configurable: true,
   value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
@@ -58,4 +64,18 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
   })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,9 +427,9 @@ diff@5.0.0:
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dompurify@^3.4.7:
-  version "3.4.11"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
-  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
Closes #402

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `68 suites / 850 tests (849 passed, 1 skipped) / 13 snapshots passed`,
exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  resolves to `http://localhost:5601`; added the `snapshotFormat: { escapeString: true,
  printBasicPrototype: true }` compatibility shim (Jest 29 flipped these defaults); replaced the
  `jest-raw-loader` moduleNameMapper with a local stub (`test/__mocks__/rawLoaderMock.js`) since
  jest-raw-loader is incompatible with the Jest 28+ transformer API.
- **Setup (`test/setup.jest.ts`):** switched the jest-dom import from the removed
  `@testing-library/jest-dom/extend-expect` entrypoint to `@testing-library/jest-dom`; made the
  `matchMedia` mock `configurable`; set `process.env.HOST = 'http://localhost:5601'` (jest-location-mock
  uses it as the base URL); re-declared non-configurable `localStorage`/`sessionStorage` as
  configurable (jsdom 26).
- **Matcher codemod:** `toBeCalled*` → `toHaveBeenCalled*` across the affected test files
  (`modal_containers.test.tsx`, `reporting_context_menu_helper.test.tsx`,
  `reporting_loading_modal.test.tsx`) — Jest 30 removed the aliases.
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 6 `.snap` files — Jest 30 refuses to load the old header.
  No snapshot content was regenerated; all `.snap` diffs are header-only.

#### Plugin-specific changes
- **`window.location` (jsdom 26 makes it non-configurable):** tests that previously reassigned
  `window.location.href` or replaced the whole `window.location` object now use the jest-location-mock
  `window.location.assign` spy instead.
  - `public/components/notebooks/components/paragraph_components/__tests__/paragraph.test.tsx` —
    replaced the `Object.defineProperty(window, 'location', …)` block in `beforeEach` with
    `window.location.assign(mockLocation.href)`.
- **Anchor-navigation tests (`note_table.test.tsx`):** `<a href="#/create">` clicks no longer
  navigate under jsdom 26. The "create notebook link" test now asserts the anchor's `href` attribute
  (`closest('a')` → `#/create`) instead of the post-click `window.location.href`. The empty-state
  test sets the hash before render via `window.location.assign('#/create')` (a mount effect reads
  `window.location.hash` to open the modal) rather than clicking the link.
- **Origin-dependent assertion (`CreateInvestigatioToolResult.test.tsx`):** updated two expected URLs
  from `http://localhost/app/investigation-notebooks` to `http://localhost:5601/app/investigation-notebooks`
  to match the new `testEnvironmentOptions.url` origin.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
