### PR TITLE
fix(test): stop transpiling ** so BigInt exponentiation survives

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,22 @@ module.exports = function (api) {
   if (api.env('test')) {
     return {
       presets: [
-        require('@babel/preset-env'),
+        [
+          require('@babel/preset-env'),
+          {
+            useBuiltIns: false,
+            // Deliberately no `targets`: this preset has always run target-less
+            // here, and narrowing to `node: 'current'` changes the whole output
+            // (native let/const, classes, ...) which breaks existing suites.
+            //
+            // The exponentiation transform is the one thing we must turn off:
+            // it rewrites `a ** b` to `Math.pow(a, b)`, which throws
+            // "Cannot convert a BigInt value to a number" on BigInt operands
+            // (`2n ** 63n`) reachable through osd-monaco. Jest runs on Node,
+            // which supports `**` natively, so skipping it is safe.
+            exclude: ['@babel/plugin-transform-exponentiation-operator'],
+          },
+        ],
         require('@babel/preset-react'),
         require('@babel/preset-typescript'),
       ],


### PR DESCRIPTION
### Description

Fix `babel.config.js` preset-env options. `require('@babel/preset-env')` as a bare call meant no options were passed — so preset-env ran target-less and rewrote `a ** b` into `Math.pow(a, b)`. That crashes on BigInt exponentiation (`2n ** 63n`) now pulled in transitively from `osd-monaco`'s PPL lint code, causing test suites to fail to load.

Passing options as a `[preset, options]` tuple and excluding the exponentiation transform fixes it.

### Issues Resolved

Fixes CI unit test suite load failures (`TypeError: Cannot convert a BigInt value to a number`).

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).