### PR TITLE
fix: bound notebook bulk-delete work

### DIFF
--- a/server/adaptors/notebooks/__tests__/saved_objects_paragraphs_router.test.ts
+++ b/server/adaptors/notebooks/__tests__/saved_objects_paragraphs_router.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsClientContract } from '../../../../../../src/core/server/types';
+import { NOTEBOOK_SAVED_OBJECT } from '../../../../common/types/observability_saved_object_attributes';
+import { batchDeleteParagraphs } from '../saved_objects_paragraphs_router';
+
+describe('batchDeleteParagraphs', () => {
+  const buildParagraphs = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({ id: `paragraph_${i}`, input: {}, output: [] }));
+
+  const createMockClient = (paragraphs: unknown[]) => {
+    const attributes = {
+      savedNotebook: {
+        paragraphs,
+        dateModified: '2020-01-01T00:00:00.000Z',
+      },
+    };
+    return {
+      get: jest.fn().mockResolvedValue({ attributes, version: 'v1' }),
+      create: jest.fn().mockResolvedValue({ id: 'note-1' }),
+    } as unknown as SavedObjectsClientContract & {
+      get: jest.Mock;
+      create: jest.Mock;
+    };
+  };
+
+  it('excludes only the paragraphs whose ids are supplied', async () => {
+    const client = createMockClient(buildParagraphs(5));
+
+    await batchDeleteParagraphs(
+      { noteId: 'note-1', paragraphIds: ['paragraph_1', 'paragraph_3'] },
+      client
+    );
+
+    const persistedParagraphs = client.create.mock.calls[0][1].savedNotebook.paragraphs;
+    expect(persistedParagraphs.map((p: { id: string }) => p.id)).toEqual([
+      'paragraph_0',
+      'paragraph_2',
+      'paragraph_4',
+    ]);
+  });
+
+  it('leaves paragraphs untouched when no ids match', async () => {
+    const client = createMockClient(buildParagraphs(3));
+
+    const result = await batchDeleteParagraphs(
+      { noteId: 'note-1', paragraphIds: ['does_not_exist'] },
+      client
+    );
+
+    expect(result).toEqual({ result: { id: 'note-1' } });
+    const persistedParagraphs = client.create.mock.calls[0][1].savedNotebook.paragraphs;
+    expect(persistedParagraphs).toHaveLength(3);
+  });
+
+  it('persists with overwrite and the fetched version', async () => {
+    const client = createMockClient(buildParagraphs(2));
+
+    await batchDeleteParagraphs({ noteId: 'note-1', paragraphIds: ['paragraph_0'] }, client);
+
+    expect(client.create).toHaveBeenCalledWith(
+      NOTEBOOK_SAVED_OBJECT,
+      expect.any(Object),
+      expect.objectContaining({ id: 'note-1', overwrite: true, version: 'v1' })
+    );
+  });
+
+  it('deduplicates repeated ids without extra work (Set-based exclusion)', async () => {
+    const client = createMockClient(buildParagraphs(3));
+
+    await batchDeleteParagraphs(
+      { noteId: 'note-1', paragraphIds: ['paragraph_1', 'paragraph_1', 'paragraph_1'] },
+      client
+    );
+
+    const persistedParagraphs = client.create.mock.calls[0][1].savedNotebook.paragraphs;
+    expect(persistedParagraphs.map((p: { id: string }) => p.id)).toEqual([
+      'paragraph_0',
+      'paragraph_2',
+    ]);
+  });
+
+  it('throws a wrapped error when persistence fails', async () => {
+    const client = createMockClient(buildParagraphs(1));
+    client.create.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      batchDeleteParagraphs({ noteId: 'note-1', paragraphIds: ['paragraph_0'] }, client)
+    ).rejects.toThrow('delete Paragraphs Error:');
+  });
+});

--- a/server/adaptors/notebooks/saved_objects_paragraphs_router.tsx
+++ b/server/adaptors/notebooks/saved_objects_paragraphs_router.tsx
@@ -248,8 +248,9 @@ export async function batchDeleteParagraphs(
   opensearchNotebooksClient: SavedObjectsClientContract
 ) {
   const noteBookInfo = await fetchNotebook(params.noteId, opensearchNotebooksClient);
+  const paragraphIdsToDelete = new Set(params.paragraphIds);
   const updatedparagraphs = noteBookInfo.attributes.savedNotebook.paragraphs.filter(
-    (paragraph: ParagraphBackendType<unknown>) => !params.paragraphIds.includes(paragraph.id)
+    (paragraph: ParagraphBackendType<unknown>) => !paragraphIdsToDelete.has(paragraph.id)
   );
 
   noteBookInfo.attributes.savedNotebook.paragraphs = updatedparagraphs;

--- a/server/routes/notebooks/__tests__/paragraph_router.test.ts
+++ b/server/routes/notebooks/__tests__/paragraph_router.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpServiceMock } from '../../../../../../src/core/server/mocks';
+import { NOTEBOOKS_API_PREFIX } from '../../../../common/constants/notebooks';
+import { registerParaRoute } from '../paragraph_router';
+
+describe('Paragraph Router - bulk delete validation', () => {
+  const getDeleteBodySchema = () => {
+    const mockRouter = httpServiceMock.createSetupContract().createRouter();
+    registerParaRoute(mockRouter);
+
+    const deleteCall = (mockRouter.delete as jest.Mock).mock.calls.find(
+      ([config]) => config.path === `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraphs`
+    );
+    expect(deleteCall).toBeDefined();
+    return deleteCall[0].validate.body;
+  };
+
+  it('accepts a paragraphIds array at the cap', () => {
+    const bodySchema = getDeleteBodySchema();
+    const paragraphIds = Array.from({ length: 1000 }, (_, i) => `paragraph_${i}`);
+
+    expect(() => bodySchema.validate({ noteId: 'note-1', paragraphIds })).not.toThrow();
+  });
+
+  it('rejects a paragraphIds array over the cap', () => {
+    const bodySchema = getDeleteBodySchema();
+    const paragraphIds = Array.from({ length: 1001 }, (_, i) => `paragraph_${i}`);
+
+    expect(() => bodySchema.validate({ noteId: 'note-1', paragraphIds })).toThrow(
+      /array size is \[1001\], but cannot be greater than \[1000\]/
+    );
+  });
+});

--- a/server/routes/notebooks/paragraph_router.ts
+++ b/server/routes/notebooks/paragraph_router.ts
@@ -181,7 +181,7 @@ export function registerParaRoute(router: IRouter) {
       validate: {
         body: schema.object({
           noteId: schema.string(),
-          paragraphIds: schema.arrayOf(schema.string()),
+          paragraphIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
         }),
       },
     },


### PR DESCRIPTION
### Description

The `DELETE /api/investigation/savedNotebook/paragraphs` route validated `paragraphIds` as an unbounded string array and removed matching paragraphs by calling `Array.includes()` once per stored paragraph. That makes the delete handler `O(P × N)` (P = stored paragraphs, N = supplied ids) running synchronously.

This PR bounds both dimensions of that work:

- **Cap the input.** `paragraphIds` is now `schema.arrayOf(schema.string(), { maxSize: 1000 })` in the route validation schema, so oversized requests are rejected before reaching the handler.
- **Linear-time filtering.** Build a `Set` from `paragraphIds` once and filter with `Set.has()`, reducing the exclusion pass from `O(P × N)` to `O(P + N)`.

Added unit tests:
- Route schema accepts an array at the cap and rejects one over it.
- `batchDeleteParagraphs` excludes only the supplied ids, handles duplicate/non-matching ids, and persists with `overwrite` + the fetched version.

### Issues Resolved

Addresses an authenticated event-loop exhaustion issue in the notebook bulk-delete endpoint.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
